### PR TITLE
Add support for closures in the interpreter

### DIFF
--- a/crates/aquascope/src/interpreter/miri_utils.rs
+++ b/crates/aquascope/src/interpreter/miri_utils.rs
@@ -142,6 +142,11 @@ pub fn locate_address_in_type<'mir, 'tcx>(
   let mut offset = 0;
   if alloc_layout.size.bytes() < alloc_size.bytes() {
     let array_elem_size = alloc_layout.size.bytes();
+    assert!(
+      array_elem_size > 0,
+      "Array has zero-sized elements: {alloc_layout:#?}"
+    );
+
     offset = target.bytes() / array_elem_size * array_elem_size;
     let index = offset / array_elem_size;
     // dbg!((array_elem_size, offset, index));

--- a/crates/aquascope/src/interpreter/mvalue.rs
+++ b/crates/aquascope/src/interpreter/mvalue.rs
@@ -1,16 +1,19 @@
 //! Interpreting memory as Rust data types
 
+use std::collections::HashMap;
+
 use miri::{
-  AllocMap, Immediate, InterpError, InterpErrorInfo, InterpResult, MPlaceTy,
-  MemPlaceMeta, MemoryKind, OpTy, UndefinedBehaviorInfo, Value,
+  AllocKind, AllocMap, Immediate, InterpError, InterpErrorInfo, InterpResult,
+  MPlaceTy, MemPlaceMeta, MemoryKind, OpTy, UndefinedBehaviorInfo, Value,
 };
 use rustc_abi::FieldsShape;
 use rustc_apfloat::Float;
+use rustc_hir::def_id::DefId;
 use rustc_middle::{
-  mir::PlaceElem,
+  mir::{PlaceElem, ProjectionElem, VarDebugInfo, VarDebugInfoContents},
   ty::{
     layout::{LayoutOf, TyAndLayout},
-    AdtKind, Ty, TyKind,
+    AdtKind, ClosureKind, Instance, SubstsRef, Ty, TyKind,
   },
 };
 use rustc_target::abi::Size;
@@ -186,6 +189,11 @@ impl<'tcx> Reader<'_, '_, 'tcx> {
   ) -> InterpResult<'tcx, MValue> {
     // Determine the base allocation from the mplace's provenance
     let (alloc_id, offset, _) = self.ev.ecx.ptr_get_alloc_id(mplace.ptr)?;
+    let (alloc_size, _, alloc_status) = self.ev.ecx.get_alloc_info(alloc_id);
+
+    if matches!(alloc_status, AllocKind::Dead) {
+      log::warn!("Reading a dead allocation");
+    }
 
     // Check if we have seen this allocation before
     let alloc_discovered = self
@@ -242,7 +250,6 @@ impl<'tcx> Reader<'_, '_, 'tcx> {
 
     let (segment, alloc_layout) =
       self.ev.memory_map.borrow().place_to_loc[&alloc_id].clone();
-    let (alloc_size, _, _) = self.ev.ecx.get_alloc_info(alloc_id);
 
     // The pointer could point anywhere inside the allocation, so we use
     // `get_path_segments` to reverse-engineer a path from the memory location.
@@ -463,6 +470,25 @@ impl<'tcx> Reader<'_, '_, 'tcx> {
         self.read_pointer(mplace)?
       }
 
+      TyKind::Closure(def_id, substs) => {
+        let closure = substs.as_closure();
+
+        let name = self.ev.fn_name(*def_id);
+        let upvar_names = self.ev.closure_upvar_names(*def_id, substs)?;
+
+        let env_ty = closure.tupled_upvars_ty();
+        let mut env_op = op.clone();
+        env_op.layout.ty = env_ty;
+        let MValue::Tuple(env) = self.read(&env_op)? else { unreachable!() };
+        let fields = upvar_names.into_iter().zip(env).collect();
+        MValue::Adt {
+          name,
+          variant: None,
+          fields,
+          alloc_kind: None,
+        }
+      }
+
       kind => todo!("{:?} / {:?}", **op, kind),
     };
 
@@ -480,5 +506,45 @@ impl<'tcx> VisEvaluator<'_, 'tcx> {
       heap_alloc_kinds: Vec::new(),
     }
     .read(op)
+  }
+
+  fn closure_upvar_names(
+    &self,
+    def_id: DefId,
+    substs: SubstsRef<'tcx>,
+  ) -> InterpResult<'tcx, Vec<String>> {
+    let closure = substs.as_closure();
+    let inst = Instance::new(def_id, substs);
+    let body = self.ecx.load_mir(inst.def, None)?;
+    let mut upvar_names = body
+      .var_debug_info
+      .iter()
+      .filter_map(|VarDebugInfo { name, value, .. }| match value {
+        VarDebugInfoContents::Place(place) if place.local.as_usize() == 1 => {
+          // If it's a FnOnce closure, then the environment is moved
+          // and the places are like _1.0, _1.1, etc.
+          // Otherwise, the environment is passed by reference and the
+          // places are like (*_1).0, (*_1).1, so we need to index
+          // the appropriate projection.
+          let projection_idx = match closure.kind() {
+            ClosureKind::FnOnce => 0,
+            ClosureKind::Fn | ClosureKind::FnMut => 1,
+          };
+          match place.projection.get(projection_idx)? {
+            ProjectionElem::Field(field, _) => {
+              Some((field.as_usize(), name.to_ident_string()))
+            }
+            _ => None,
+          }
+        }
+        _ => None,
+      })
+      .collect::<HashMap<_, _>>();
+
+    Ok(
+      (0 .. closure.upvar_tys().count())
+        .map(|i| upvar_names.remove(&i).unwrap_or_else(|| "(tmp)".into()))
+        .collect(),
+    )
   }
 }

--- a/crates/aquascope/src/interpreter/step.rs
+++ b/crates/aquascope/src/interpreter/step.rs
@@ -201,7 +201,9 @@ impl<'mir, 'tcx> VisEvaluator<'mir, 'tcx> {
 
       "(return)".into()
     } else {
-      // Only keep locals corresponding to user-defined variables
+      // TODO: this excludes compiler-generated temporaries which we sometimes need to
+      // visualize in the case of f(&Some(x)). Need to figure out a good strategy for
+      // deciding when a temp should be included.
       if !matches!(
         decl.local_info,
         Some(box LocalInfo::User(ClearCrossCrate::Set(_)))
@@ -211,7 +213,7 @@ impl<'mir, 'tcx> VisEvaluator<'mir, 'tcx> {
 
       Place::from_local(local, *self.ecx.tcx)
         .to_string(*self.ecx.tcx, frame.body)
-        .unwrap()
+        .unwrap_or_else(|| String::from("(tmp)"))
     };
 
     let layout = state.layout.get();

--- a/crates/aquascope/tests/interpreter/closure.test
+++ b/crates/aquascope/tests/interpreter/closure.test
@@ -1,0 +1,5 @@
+fn main() {
+  let x = 0;
+  let f = || x;
+  let y = f();  
+}

--- a/crates/aquascope/tests/snapshots/interpreter__box.test.snap
+++ b/crates/aquascope/tests/snapshots/interpreter__box.test.snap
@@ -16,19 +16,22 @@ steps:
             filename: 0
           locals:
             - - x
-              - type: Struct
+              - type: Adt
                 value:
                   name: Box
+                  variant: ~
                   fields:
                     - - "0"
-                      - type: Struct
+                      - type: Adt
                         value:
                           name: Unique
+                          variant: ~
                           fields:
                             - - pointer
-                              - type: Struct
+                              - type: Adt
                                 value:
                                   name: NonNull
+                                  variant: ~
                                   fields:
                                     - - pointer
                                       - type: Pointer
@@ -61,19 +64,22 @@ steps:
             filename: 0
           locals:
             - - x
-              - type: Struct
+              - type: Adt
                 value:
                   name: Box
+                  variant: ~
                   fields:
                     - - "0"
-                      - type: Struct
+                      - type: Adt
                         value:
                           name: Unique
+                          variant: ~
                           fields:
                             - - pointer
-                              - type: Struct
+                              - type: Adt
                                 value:
                                   name: NonNull
+                                  variant: ~
                                   fields:
                                     - - pointer
                                       - type: Pointer
@@ -106,19 +112,22 @@ steps:
             filename: 0
           locals:
             - - x
-              - type: Struct
+              - type: Adt
                 value:
                   name: Box
+                  variant: ~
                   fields:
                     - - "0"
-                      - type: Struct
+                      - type: Adt
                         value:
                           name: Unique
+                          variant: ~
                           fields:
                             - - pointer
-                              - type: Struct
+                              - type: Adt
                                 value:
                                   name: NonNull
+                                  variant: ~
                                   fields:
                                     - - pointer
                                       - type: Pointer
@@ -135,19 +144,22 @@ steps:
                   alloc_kind:
                     type: Box
             - - y
-              - type: Struct
+              - type: Adt
                 value:
                   name: Box
+                  variant: ~
                   fields:
                     - - "0"
-                      - type: Struct
+                      - type: Adt
                         value:
                           name: Unique
+                          variant: ~
                           fields:
                             - - pointer
-                              - type: Struct
+                              - type: Adt
                                 value:
                                   name: NonNull
+                                  variant: ~
                                   fields:
                                     - - pointer
                                       - type: Pointer

--- a/crates/aquascope/tests/snapshots/interpreter__closure.test.snap
+++ b/crates/aquascope/tests/snapshots/interpreter__closure.test.snap
@@ -1,0 +1,240 @@
+---
+source: crates/aquascope/tests/interpreter.rs
+description: closure.test
+---
+steps:
+  - stack:
+      frames:
+        - name: main
+          body_span:
+            char_start: 0
+            char_end: 59
+            filename: 0
+          location:
+            char_start: 14
+            char_end: 24
+            filename: 0
+          locals:
+            - - x
+              - type: Int
+                value: 0
+    heap:
+      locations: []
+  - stack:
+      frames:
+        - name: main
+          body_span:
+            char_start: 0
+            char_end: 59
+            filename: 0
+          location:
+            char_start: 27
+            char_end: 40
+            filename: 0
+          locals:
+            - - x
+              - type: Int
+                value: 0
+            - - f
+              - type: Adt
+                value:
+                  name: "main::{closure#0}"
+                  variant: ~
+                  fields:
+                    - - x
+                      - type: Pointer
+                        value:
+                          path:
+                            segment:
+                              type: Stack
+                              value:
+                                frame: 0
+                                local: x
+                            parts: []
+                          range: ~
+                  alloc_kind: ~
+    heap:
+      locations: []
+  - stack:
+      frames:
+        - name: main
+          body_span:
+            char_start: 0
+            char_end: 59
+            filename: 0
+          location:
+            char_start: 43
+            char_end: 55
+            filename: 0
+          locals:
+            - - x
+              - type: Int
+                value: 0
+            - - f
+              - type: Adt
+                value:
+                  name: "main::{closure#0}"
+                  variant: ~
+                  fields:
+                    - - x
+                      - type: Pointer
+                        value:
+                          path:
+                            segment:
+                              type: Stack
+                              value:
+                                frame: 0
+                                local: x
+                            parts: []
+                          range: ~
+                  alloc_kind: ~
+    heap:
+      locations: []
+  - stack:
+      frames:
+        - name: main
+          body_span:
+            char_start: 0
+            char_end: 59
+            filename: 0
+          location:
+            char_start: 43
+            char_end: 55
+            filename: 0
+          locals:
+            - - x
+              - type: Int
+                value: 0
+            - - f
+              - type: Adt
+                value:
+                  name: "main::{closure#0}"
+                  variant: ~
+                  fields:
+                    - - x
+                      - type: Pointer
+                        value:
+                          path:
+                            segment:
+                              type: Stack
+                              value:
+                                frame: 0
+                                local: x
+                            parts: []
+                          range: ~
+                  alloc_kind: ~
+        - name: "main::{closure#0}"
+          body_span:
+            char_start: 35
+            char_end: 39
+            filename: 0
+          location:
+            char_start: 35
+            char_end: 37
+            filename: 0
+          locals: []
+    heap:
+      locations: []
+  - stack:
+      frames:
+        - name: main
+          body_span:
+            char_start: 0
+            char_end: 59
+            filename: 0
+          location:
+            char_start: 43
+            char_end: 55
+            filename: 0
+          locals:
+            - - x
+              - type: Int
+                value: 0
+            - - f
+              - type: Adt
+                value:
+                  name: "main::{closure#0}"
+                  variant: ~
+                  fields:
+                    - - x
+                      - type: Pointer
+                        value:
+                          path:
+                            segment:
+                              type: Stack
+                              value:
+                                frame: 0
+                                local: x
+                            parts: []
+                          range: ~
+                  alloc_kind: ~
+        - name: "main::{closure#0}"
+          body_span:
+            char_start: 35
+            char_end: 39
+            filename: 0
+          location:
+            char_start: 38
+            char_end: 39
+            filename: 0
+          locals:
+            - - (return)
+              - type: Int
+                value: 0
+    heap:
+      locations: []
+  - stack:
+      frames:
+        - name: main
+          body_span:
+            char_start: 0
+            char_end: 59
+            filename: 0
+          location:
+            char_start: 43
+            char_end: 55
+            filename: 0
+          locals:
+            - - x
+              - type: Int
+                value: 0
+            - - f
+              - type: Adt
+                value:
+                  name: "main::{closure#0}"
+                  variant: ~
+                  fields:
+                    - - x
+                      - type: Pointer
+                        value:
+                          path:
+                            segment:
+                              type: Stack
+                              value:
+                                frame: 0
+                                local: x
+                            parts: []
+                          range: ~
+                  alloc_kind: ~
+            - - y
+              - type: Int
+                value: 0
+    heap:
+      locations: []
+  - stack:
+      frames:
+        - name: main
+          body_span:
+            char_start: 0
+            char_end: 59
+            filename: 0
+          location:
+            char_start: 58
+            char_end: 59
+            filename: 0
+          locals: []
+    heap:
+      locations: []
+result:
+  type: Success
+

--- a/crates/aquascope/tests/snapshots/interpreter__error.test.snap
+++ b/crates/aquascope/tests/snapshots/interpreter__error.test.snap
@@ -16,24 +16,28 @@ steps:
             filename: 0
           locals:
             - - v
-              - type: Struct
+              - type: Adt
                 value:
                   name: Vec
+                  variant: ~
                   fields:
                     - - buf
-                      - type: Struct
+                      - type: Adt
                         value:
                           name: RawVec
+                          variant: ~
                           fields:
                             - - ptr
-                              - type: Struct
+                              - type: Adt
                                 value:
                                   name: Unique
+                                  variant: ~
                                   fields:
                                     - - pointer
-                                      - type: Struct
+                                      - type: Adt
                                         value:
                                           name: NonNull
+                                          variant: ~
                                           fields:
                                             - - pointer
                                               - type: Pointer
@@ -85,24 +89,28 @@ steps:
             filename: 0
           locals:
             - - v
-              - type: Struct
+              - type: Adt
                 value:
                   name: Vec
+                  variant: ~
                   fields:
                     - - buf
-                      - type: Struct
+                      - type: Adt
                         value:
                           name: RawVec
+                          variant: ~
                           fields:
                             - - ptr
-                              - type: Struct
+                              - type: Adt
                                 value:
                                   name: Unique
+                                  variant: ~
                                   fields:
                                     - - pointer
-                                      - type: Struct
+                                      - type: Adt
                                         value:
                                           name: NonNull
+                                          variant: ~
                                           fields:
                                             - - pointer
                                               - type: Pointer
@@ -166,24 +174,28 @@ steps:
             filename: 0
           locals:
             - - v
-              - type: Struct
+              - type: Adt
                 value:
                   name: Vec
+                  variant: ~
                   fields:
                     - - buf
-                      - type: Struct
+                      - type: Adt
                         value:
                           name: RawVec
+                          variant: ~
                           fields:
                             - - ptr
-                              - type: Struct
+                              - type: Adt
                                 value:
                                   name: Unique
+                                  variant: ~
                                   fields:
                                     - - pointer
-                                      - type: Struct
+                                      - type: Adt
                                         value:
                                           name: NonNull
+                                          variant: ~
                                           fields:
                                             - - pointer
                                               - type: Pointer
@@ -241,24 +253,28 @@ steps:
             filename: 0
           locals:
             - - v
-              - type: Struct
+              - type: Adt
                 value:
                   name: Vec
+                  variant: ~
                   fields:
                     - - buf
-                      - type: Struct
+                      - type: Adt
                         value:
                           name: RawVec
+                          variant: ~
                           fields:
                             - - ptr
-                              - type: Struct
+                              - type: Adt
                                 value:
                                   name: Unique
+                                  variant: ~
                                   fields:
                                     - - pointer
-                                      - type: Struct
+                                      - type: Adt
                                         value:
                                           name: NonNull
+                                          variant: ~
                                           fields:
                                             - - pointer
                                               - type: Pointer

--- a/crates/mdbook-aquascope/Cargo.toml
+++ b/crates/mdbook-aquascope/Cargo.toml
@@ -34,6 +34,7 @@ rayon = "1"
 aquascope_workspace_utils = { path = "../aquascope_workspace_utils" }
 regex = "1"
 flate2 = "1"
+wait-timeout = "0.2"
 
 [dev-dependencies]
 mdbook-aquascope = { path = ".", features = ["dev"] }

--- a/frontend/packages/aquascope-editor/src/editor-utils/interpreter.tsx
+++ b/frontend/packages/aquascope-editor/src/editor-utils/interpreter.tsx
@@ -152,7 +152,9 @@ let AdtView = ({ value }: { value: MAdt }) => {
     </>
   );
 
-  if (value.fields.length == 1) {
+  let isTuple = value.fields.length > 0 && value.fields[0][0] == "0";
+
+  if (isTuple && value.fields.length == 1) {
     let path = [...pathCtx, "field", "0"];
     return (
       <span className={path.join("-")}>
@@ -163,8 +165,6 @@ let AdtView = ({ value }: { value: MAdt }) => {
       </span>
     );
   }
-
-  let isTuple = value.fields.length > 0 && value.fields[0][0] == "0";
 
   return (
     <>

--- a/frontend/packages/aquascope-editor/src/editor-utils/stepper.tsx
+++ b/frontend/packages/aquascope-editor/src/editor-utils/stepper.tsx
@@ -256,9 +256,11 @@ let StepTable = ({
   facts: AnalysisFacts;
 }) => (
   <table className="perm-step-table">
-    {rows.map(([path, diffs], i: number) => (
-      <PermDiffRow key={i} path={path} diffs={diffs} facts={facts} />
-    ))}
+    <tbody>
+      {rows.map(([path, diffs], i: number) => (
+        <PermDiffRow key={i} path={path} diffs={diffs} facts={facts} />
+      ))}
+    </tbody>
   </table>
 );
 

--- a/frontend/packages/aquascope-embed/src/lib.ts
+++ b/frontend/packages/aquascope-embed/src/lib.ts
@@ -63,23 +63,29 @@ let initEditors = () => {
       ["copy"]
     );
 
-    let operation = elem.dataset.operation;
-    if (!operation) throw new Error("Missing data-operation attribute");
+    let operations = maybeParseJson<string[]>(elem.dataset.operations);
+    if (!operations) throw new Error("Missing data-operations attribute");
 
-    let response = maybeParseJson<Result<any>>(elem.dataset.response);
+    let responses = maybeParseJson<{ [op: string]: Result<any> }>(
+      elem.dataset.responses
+    );
     let config = maybeParseJson<any>(elem.dataset.config);
     let annotations = maybeParseJson<types.AquascopeAnnotations>(
       elem.dataset.annotations
     );
 
-    ed.renderOperation(operation, {
-      response,
-      config,
-      annotations,
-    });
+    if (responses) {
+      operations.forEach(operation => {
+        ed.renderOperation(operation, {
+          response: responses![operation],
+          config,
+          annotations,
+        });
+      });
+    }
 
     computePermBtn?.addEventListener("click", _ => {
-      ed.renderOperation(operation!, {});
+      operations!.forEach(operation => ed.renderOperation(operation!, {}));
     });
   });
 };


### PR DESCRIPTION
Also:
* Fixed some `shouldFail` programs getting rejected during MIR optimization
* Add support for multiple operations in a single Aquascope block via the syntax `interpreter+permissions`
* Reduces `MStruct` and `MEnum` to a single `MAdt`