### PR TITLE
Patching boundaries and permissions

### DIFF
--- a/crates/aquascope/src/analysis/boundaries/mod.rs
+++ b/crates/aquascope/src/analysis/boundaries/mod.rs
@@ -339,6 +339,14 @@ fn paths_at_hir_id<'a, 'tcx: 'a>(
       {
         smallvec![(loc, **place)]
       }
+      StatementKind::FakeRead(box (_, place))
+        if place.is_source_visible(tcx, body) =>
+      {
+        smallvec![(loc, *place)]
+      }
+
+      StatementKind::SetDiscriminant { .. }
+      | StatementKind::FakeRead(..)
 
       // These variants are compiler generated, but it would be
       // insufficient to find a source-visible place only in
@@ -346,8 +354,6 @@ fn paths_at_hir_id<'a, 'tcx: 'a>(
       //
       // They are also unimplemented so if something is missing
       // suspect something in here.
-      StatementKind::SetDiscriminant { .. }
-      | StatementKind::FakeRead(..)
       | StatementKind::Deinit(..)
       | StatementKind::StorageLive(..)
       | StatementKind::StorageDead(..)

--- a/crates/aquascope/src/analysis/permissions/output.rs
+++ b/crates/aquascope/src/analysis/permissions/output.rs
@@ -132,6 +132,27 @@ where
   ///   move_conflicts_with(Move, Path).
   pub(crate) move_refined: HashMap<T::Point, HashMap<T::Path, Move>>,
 
+  /// The liveness of a [`Move`] on [`Point`] entry.
+  ///
+  /// ```text
+  /// .decl move_live_at(Move, Point)
+  ///
+  /// move_live_at(Move, Point) :-
+  ///   move_out(Move, Point).
+  ///
+  /// move_live_at(Move, Point1) :-
+  ///   move_live_at(Move, Point0),
+  ///   cfg_edge(Point0, Point1),
+  ///   move_conflicts_with(Move, Path0),
+  ///   !conflicted_assign_at_base(Path0, Point).
+  ///
+  /// .decl conflicted_assign_at_base(Path0, Point)
+  ///
+  /// conflicted_assign_at_base(Path0, Point) :-
+  ///   path_assigned_at_base(Path1, Point),
+  ///   places_conflict(Path0, Path1),
+  /// ```
+  ///
   pub(crate) move_live_at: HashMap<T::Point, Vec<Move>>,
 }
 
@@ -150,8 +171,8 @@ impl Default for Output<AquascopeFacts> {
 }
 
 /// Populate the [`Output`] facts in the current [`PermissionsCtxt`].
-// TODO(gavinleroy) lots of data is kept around below for clarity,
-// but this could definitely be optimized.
+// TODO(gavinleroy) lots of data is kept around below for clarity, but
+// this could definitely be optimized (for performance and memory consumption).
 #[allow(clippy::similar_names)]
 pub fn derive_permission_facts(ctxt: &mut PermissionsCtxt) {
   let def_id = ctxt.tcx.hir().body_owner_def_id(ctxt.body_id);
@@ -249,7 +270,6 @@ pub fn derive_permission_facts(ctxt: &mut PermissionsCtxt) {
   // Paths that are partially moved can not have R/O permissions,
   // thus, if a child path is uninitialized (moved or non-initialized),
   // then the parent must also be uninitialized.
-
   let mut iteration = Iteration::new();
 
   let path_maybe_uninitialized_on_entry =
@@ -274,22 +294,34 @@ pub fn derive_permission_facts(ctxt: &mut PermissionsCtxt) {
     |&_point1, &path, &point2| (path, point2),
   ));
 
-  // FIXME: a lot of these do repeat work. You could rely on datafrog more.
   while iteration.changed() {
-    // TODO: write datalog rule
+    // move_live_at(Move, Point1) :-
+    //   move_live_at(Move, Point0),
+    //   cfg_edge(Point0, Point1),
+    //   move_conflicts_with(Move, Path0),
+    //   !conflicted_assign_at_base(Path0, Point).
     move_live_at.from_leapjoin(
       &move_live_at,
       (
         cfg_edge.extend_with(|&(_path, point1)| point1),
         ValueFilter::from(|&(movep, _point1), &point2| {
           let mpath = ctxt.move_to_moveable_path(movep);
+          let mp = ctxt.moveable_path_to_path(mpath);
+          let place2 = ctxt.path_to_place(mp);
+
+          // TODO: we can pull this out into its own rule. I'm
+          //       hesitant to pre-compute everything over the
+          //       entire domain because I'm not sure it's worth
+          //       the memory footprint.
+          //
+          // conflicted_assign_at_base(Path0, Point) :-
+          //   path_assigned_at_base(Path1, Point),
+          //   places_conflict(Path0, Path1),
           !ctxt.polonius_input_facts.path_assigned_at_base.iter().any(
             |&(assigned_to, p)| {
               p == point2 && {
-                let pp = ctxt.moveable_path_to_path(assigned_to);
-                let place1 = ctxt.path_to_place(pp);
-                let pp = ctxt.moveable_path_to_path(mpath);
-                let place2 = ctxt.path_to_place(pp);
+                let mp_assigned_to = ctxt.moveable_path_to_path(assigned_to);
+                let place1 = ctxt.path_to_place(mp_assigned_to);
                 places_conflict::places_conflict(
                   tcx,
                   body,
@@ -319,7 +351,9 @@ pub fn derive_permission_facts(ctxt: &mut PermissionsCtxt) {
     path_maybe_uninitialized_on_entry.complete();
   let move_live_at = move_live_at.complete();
 
-  // We need to shift the move liveness by one in the MIR.
+  // NOTE: We need to shift the move liveness by one in the MIR. Move
+  //       liveness is defined as a move being live *on point entry*,
+  //       but it was computed on point exit.
   let move_live_at: Relation<(Move, Point)> = Relation::from_leapjoin(
     &move_live_at,
     cfg_edge.extend_with(|&(_movep, point1)| point1),
@@ -336,19 +370,17 @@ pub fn derive_permission_facts(ctxt: &mut PermissionsCtxt) {
           matches!(elem, ProjectionElem::Deref).then_some(prefix)
         })
         .any(|prefix| {
+          // For a given path `*x` we could be looking at the prefix of
+          // `x`. This could be a reference, in which case we simply check
+          // the mutability of the type.
           let ty = prefix.ty(&body.local_decls, tcx).ty;
-          log::debug!(
-            "checking to see if prefix {:?}: {:?} is mutable",
-            prefix,
-            ty
-          );
-
           if let Some(mutability) = ty.ref_mutability() {
             return mutability == Mutability::Not;
           }
 
-          // If the type is not a ref, it could be an array or box. In these
-          // cases we defer back to the mutability of the binding.
+          // In the above example of `*x`, example `x` could also be a
+          // `Box`, or for a different base path an array. These cases
+          // would require us to check the mutability binding of the local.
           let local_place = Place::from_local(prefix.local, tcx);
           ctxt.is_declared_readonly(&local_place)
         })

--- a/crates/aquascope/tests/boundaries/array.test
+++ b/crates/aquascope/tests/boundaries/array.test
@@ -1,0 +1,19 @@
+fn arr() {
+  let a = [0; 10];
+  a[0] += 1;
+}
+
+fn mut_arr() {
+  let mut a = [0; 10];
+  a[0] += 1;
+}
+
+fn slice() {
+  let a = &[0; 10];
+  a[0] += 1;
+}
+
+fn mut_slice() {
+  let a = &mut [0; 10];
+  a[0] += 1;
+}

--- a/crates/aquascope/tests/boundaries/box.test
+++ b/crates/aquascope/tests/boundaries/box.test
@@ -1,9 +1,9 @@
-fn declared_ro() {
+fn bx() {
   let bx = Box::new(0);
   *bx += 1;
 }
 
-fn declared_mut() {
+fn mut_bx() {
   let mut bx = Box::new(0);
   *bx += 1;
 }

--- a/crates/aquascope/tests/boundaries/box.test
+++ b/crates/aquascope/tests/boundaries/box.test
@@ -1,0 +1,9 @@
+fn declared_ro() {
+  let bx = Box::new(0);
+  *bx += 1;
+}
+
+fn declared_mut() {
+  let mut bx = Box::new(0);
+  *bx += 1;
+}

--- a/crates/aquascope/tests/snapshots/boundaries__arr@array.test.snap
+++ b/crates/aquascope/tests/snapshots/boundaries__arr@array.test.snap
@@ -1,0 +1,20 @@
+---
+source: crates/aquascope/tests/boundaries.rs
+description: arr@array.test
+---
+- location: 32
+  expected:
+    read: true
+    write: true
+    drop: false
+  actual:
+    type_droppable: true
+    type_writeable: false
+    type_copyable: true
+    is_live: true
+    path_uninitialized: false
+    permissions:
+      read: true
+      write: false
+      drop: true
+

--- a/crates/aquascope/tests/snapshots/boundaries__bx@box.test.snap
+++ b/crates/aquascope/tests/snapshots/boundaries__bx@box.test.snap
@@ -1,0 +1,20 @@
+---
+source: crates/aquascope/tests/boundaries.rs
+description: bx@box.test
+---
+- location: 36
+  expected:
+    read: true
+    write: true
+    drop: false
+  actual:
+    type_droppable: false
+    type_writeable: false
+    type_copyable: true
+    is_live: true
+    path_uninitialized: false
+    permissions:
+      read: true
+      write: false
+      drop: true
+

--- a/crates/aquascope/tests/snapshots/boundaries__declared_mut@box.test.snap
+++ b/crates/aquascope/tests/snapshots/boundaries__declared_mut@box.test.snap
@@ -1,0 +1,20 @@
+---
+source: crates/aquascope/tests/boundaries.rs
+description: declared_mut@box.test
+---
+- location: 108
+  expected:
+    read: true
+    write: true
+    drop: false
+  actual:
+    type_droppable: false
+    type_writeable: true
+    type_copyable: true
+    is_live: true
+    path_uninitialized: false
+    permissions:
+      read: true
+      write: true
+      drop: true
+

--- a/crates/aquascope/tests/snapshots/boundaries__declared_ro@box.test.snap
+++ b/crates/aquascope/tests/snapshots/boundaries__declared_ro@box.test.snap
@@ -1,0 +1,20 @@
+---
+source: crates/aquascope/tests/boundaries.rs
+description: declared_ro@box.test
+---
+- location: 45
+  expected:
+    read: true
+    write: true
+    drop: false
+  actual:
+    type_droppable: false
+    type_writeable: false
+    type_copyable: true
+    is_live: true
+    path_uninitialized: false
+    permissions:
+      read: true
+      write: false
+      drop: true
+

--- a/crates/aquascope/tests/snapshots/boundaries__mut_arr@array.test.snap
+++ b/crates/aquascope/tests/snapshots/boundaries__mut_arr@array.test.snap
@@ -1,0 +1,20 @@
+---
+source: crates/aquascope/tests/boundaries.rs
+description: mut_arr@array.test
+---
+- location: 86
+  expected:
+    read: true
+    write: true
+    drop: false
+  actual:
+    type_droppable: true
+    type_writeable: true
+    type_copyable: true
+    is_live: true
+    path_uninitialized: false
+    permissions:
+      read: true
+      write: true
+      drop: true
+

--- a/crates/aquascope/tests/snapshots/boundaries__mut_bx@box.test.snap
+++ b/crates/aquascope/tests/snapshots/boundaries__mut_bx@box.test.snap
@@ -1,0 +1,20 @@
+---
+source: crates/aquascope/tests/boundaries.rs
+description: mut_bx@box.test
+---
+- location: 93
+  expected:
+    read: true
+    write: true
+    drop: false
+  actual:
+    type_droppable: false
+    type_writeable: true
+    type_copyable: true
+    is_live: true
+    path_uninitialized: false
+    permissions:
+      read: true
+      write: true
+      drop: true
+

--- a/crates/aquascope/tests/snapshots/boundaries__mut_slice@array.test.snap
+++ b/crates/aquascope/tests/snapshots/boundaries__mut_slice@array.test.snap
@@ -1,0 +1,20 @@
+---
+source: crates/aquascope/tests/boundaries.rs
+description: mut_slice@array.test
+---
+- location: 192
+  expected:
+    read: true
+    write: true
+    drop: false
+  actual:
+    type_droppable: false
+    type_writeable: true
+    type_copyable: true
+    is_live: true
+    path_uninitialized: false
+    permissions:
+      read: true
+      write: true
+      drop: true
+

--- a/crates/aquascope/tests/snapshots/boundaries__slice@array.test.snap
+++ b/crates/aquascope/tests/snapshots/boundaries__slice@array.test.snap
@@ -1,0 +1,20 @@
+---
+source: crates/aquascope/tests/boundaries.rs
+description: slice@array.test
+---
+- location: 135
+  expected:
+    read: true
+    write: true
+    drop: false
+  actual:
+    type_droppable: false
+    type_writeable: false
+    type_copyable: true
+    is_live: true
+    path_uninitialized: false
+    permissions:
+      read: true
+      write: false
+      drop: true
+


### PR DESCRIPTION
The MIR `FakeRead` instruction wasn't being searched when looking for existing permission on the boundaries.

A fairly serious bug was spotted in #58 which was a result of the interior places of an immutable box not having the W permission revoked due to type. This arose because we were only comparing with the `ref_mutability` of the place prefix types when we should also check if it's a box (and then check the local bindings).