### PR TITLE
Own permissions required for noncopyable types.

### DIFF
--- a/crates/aquascope/src/analysis/boundaries/path_visitor.rs
+++ b/crates/aquascope/src/analysis/boundaries/path_visitor.rs
@@ -1,22 +1,23 @@
+//! Visitor to calculate expected permissions for path usages.
+
 use anyhow::{bail, Result};
 use fluid_let::{fluid_let, fluid_set};
 use rustc_hir::{
   def::Res,
   intravisit::{self, Visitor},
-  Block, Body, BodyId, Expr, ExprKind, HirId, Mutability, Path, QPath, Stmt,
-  UnOp,
+  Block, Body, Expr, ExprKind, HirId, Path, QPath, Stmt, UnOp,
 };
 use rustc_middle::{
   hir::nested_filter::OnlyBodies,
   ty::{
-    adjustment::{Adjust, AutoBorrow, AutoBorrowMutability},
-    TyCtxt, TypeckResults,
+    adjustment::{Adjust, AutoBorrow},
+    ParamEnv, TyCtxt, TypeckResults,
   },
 };
 use rustc_span::Span;
 
-use super::{PathBoundary, Permissions};
-use crate::analysis::permissions::PermissionsCtxt;
+use super::{ExpectedPermissions, PathBoundary};
+use crate::{analysis::permissions::PermissionsCtxt, mir::utils::TyExt};
 
 // The current region flow context for outer statements and returns.
 fluid_let!(pub static FLOW_CONTEXT: HirId);
@@ -24,12 +25,13 @@ fluid_let!(pub static FLOW_CONTEXT: HirId);
 struct HirExprScraper<'a, 'tcx: 'a> {
   tcx: TyCtxt<'tcx>,
   typeck_res: &'a TypeckResults<'tcx>,
+  param_env: ParamEnv<'tcx>,
   data: Vec<PathBoundary>,
   unsupported_feature: Option<(Span, String)>,
 }
 
 impl<'a, 'tcx: 'a> HirExprScraper<'a, 'tcx> {
-  fn get_adjusted_permissions(&self, expr: &Expr) -> Permissions {
+  fn get_adjusted_permissions(&self, expr: &Expr) -> ExpectedPermissions {
     let ty_adj = self.typeck_res.expr_ty_adjusted(expr);
     let adjs = self.typeck_res.expr_adjustments(expr);
 
@@ -43,11 +45,17 @@ impl<'a, 'tcx: 'a> HirExprScraper<'a, 'tcx> {
       }
     });
 
-    Permissions {
-      read: true,
-      write: matches!(is_auto_borrow, Some(AutoBorrowMutability::Mut { .. })),
-      // Paths which are not reborrowed are moved.
-      drop: is_auto_borrow.is_none(),
+    if let Some(mutability) = is_auto_borrow {
+      return ExpectedPermissions::from_reborrow(mutability);
+    }
+
+    // At this point the usage is either a move or a copy. We
+    // can determine this whether or not the type of the path
+    // is copyable or not.
+    if ty_adj.is_copyable(self.tcx, self.param_env) {
+      ExpectedPermissions::from_copy()
+    } else {
+      ExpectedPermissions::from_move()
     }
   }
 }
@@ -93,21 +101,35 @@ impl<'a, 'tcx: 'a> Visitor<'tcx> for HirExprScraper<'a, 'tcx> {
     );
 
     match expr.kind {
-      // For method calls, it's most accurate to get the expected
+      // HACK: For method calls, it's most accurate to get the expected
       // permissions from the method signature declared type.
+      // ```text
+      // let def_id = self.typeck_res.type_dependent_def_id(hir_id).unwrap();
+      // let fn_sig = self.tcx.fn_sig(def_id).skip_binder();
+      // rcvr_ty = fn_sig.inputs()[0];
+      // ```
+      // The above reasoning was previously used, but causes problems if we
+      // need to check if the type implements `Copy`. Because the signature
+      // contains bound ty variables Ty::is_copyable panics.
+      //
+      // I would like to go back to looking at the FnSig.
       ExprKind::MethodCall(_, rcvr, args, fn_span)
         if !fn_span.from_expansion()
           && rcvr.is_place_expr(|e| !matches!(e.kind, ExprKind::Lit(_))) =>
       {
-        let def_id = self.typeck_res.type_dependent_def_id(hir_id).unwrap();
-        let fn_sig = self.tcx.fn_sig(def_id).skip_binder();
+        let rcvr_ty = self.typeck_res.expr_ty_adjusted(rcvr);
+        let expected = ExpectedPermissions::from_receiver_ty(
+          rcvr_ty,
+          self.tcx,
+          self.param_env,
+        );
 
         let pb = PathBoundary {
           location: rcvr.span,
           hir_id: rcvr.hir_id,
           flow_context,
           conflicting_node: None,
-          expected: fn_sig.inputs()[0].into(),
+          expected,
         };
 
         self.data.push(pb);
@@ -127,11 +149,7 @@ impl<'a, 'tcx: 'a> Visitor<'tcx> for HirExprScraper<'a, 'tcx> {
           flow_context,
           conflicting_node: None,
           location: inner.span.shrink_to_lo(),
-          expected: Permissions {
-            read: true,
-            write: matches!(mutability, Mutability::Mut),
-            drop: false,
-          },
+          expected: ExpectedPermissions::from_borrow(mutability),
         };
 
         self.data.push(pb);
@@ -154,11 +172,7 @@ impl<'a, 'tcx: 'a> Visitor<'tcx> for HirExprScraper<'a, 'tcx> {
           hir_id: lhs.hir_id,
           flow_context,
           conflicting_node: Some(rhs.hir_id),
-          expected: Permissions {
-            read: true,
-            write: true,
-            drop: false,
-          },
+          expected: ExpectedPermissions::from_assignment(),
         };
         self.data.push(pb);
         self.visit_expr(rhs);
@@ -190,11 +204,7 @@ impl<'a, 'tcx: 'a> Visitor<'tcx> for HirExprScraper<'a, 'tcx> {
           hir_id: lhs.hir_id,
           flow_context,
           conflicting_node: Some(rhs.hir_id),
-          expected: Permissions {
-            read: true,
-            write: true,
-            drop: false,
-          },
+          expected: ExpectedPermissions::from_assignment(),
         };
 
         self.data.push(pb);
@@ -241,13 +251,15 @@ impl<'a, 'tcx: 'a> Visitor<'tcx> for HirExprScraper<'a, 'tcx> {
 }
 
 pub(super) fn get_path_boundaries<'a, 'tcx: 'a>(
-  tcx: TyCtxt<'tcx>,
-  body_id: BodyId,
-  _ctxt: &'a PermissionsCtxt<'a, 'tcx>,
+  ctxt: &'a PermissionsCtxt<'a, 'tcx>,
 ) -> Result<Vec<PathBoundary>> {
-  let typeck_res = tcx.typeck_body(body_id);
+  let tcx = ctxt.tcx;
+  let body_id = ctxt.body_id;
+  let typeck_res = tcx.typeck_body(ctxt.body_id);
+  let param_env = ctxt.param_env;
   let mut finder = HirExprScraper {
     tcx,
+    param_env,
     typeck_res,
     unsupported_feature: None,
     data: Vec::default(),

--- a/crates/aquascope/src/analysis/permissions/mod.rs
+++ b/crates/aquascope/src/analysis/permissions/mod.rs
@@ -174,10 +174,6 @@ impl std::fmt::Debug for Permissions {
   }
 }
 
-// impl<'tcx> From<Ty<'tcx>> for Permissions {
-//   fn from(ty: Ty<'tcx>) -> Self
-// }
-
 impl<'tcx> From<FxHashMap<Place<'tcx>, PermissionsData>>
   for PermissionsDomain<'tcx>
 {

--- a/crates/aquascope/src/analysis/permissions/mod.rs
+++ b/crates/aquascope/src/analysis/permissions/mod.rs
@@ -16,10 +16,7 @@ pub use output::{compute, Output};
 use polonius_engine::FactTypes;
 use rustc_borrowck::consumers::RustcFacts;
 use rustc_data_structures::fx::FxHashMap;
-use rustc_middle::{
-  mir::{Mutability, Place},
-  ty::Ty,
-};
+use rustc_middle::mir::Place;
 use serde::Serialize;
 use ts_rs::TS;
 
@@ -149,7 +146,7 @@ pub struct PermissionsDomain<'tcx>(FxHashMap<Place<'tcx>, PermissionsData>);
 impl Permissions {
   // No "Top" value exists for permissions as this is on a per-place basis.
   // That is, the top value depends on a places type declaration.
-  pub fn bottom() -> Permissions {
+  pub fn bottom() -> Self {
     Permissions {
       read: false,
       write: false,
@@ -177,21 +174,9 @@ impl std::fmt::Debug for Permissions {
   }
 }
 
-// XXX: this is only valid when the Ty is an *expected* type.
-// This is because expected types do not rely on the mutability of
-// the binding, e.g. `let mut x = ...` and all of the expected information
-// is really just in the type.
-impl<'tcx> From<Ty<'tcx>> for Permissions {
-  fn from(ty: Ty<'tcx>) -> Self {
-    let read = true;
-    let (write, drop) = match ty.ref_mutability() {
-      None => (false, true),
-      Some(Mutability::Not) => (false, false),
-      Some(Mutability::Mut) => (true, false),
-    };
-    Self { read, write, drop }
-  }
-}
+// impl<'tcx> From<Ty<'tcx>> for Permissions {
+//   fn from(ty: Ty<'tcx>) -> Self
+// }
 
 impl<'tcx> From<FxHashMap<Place<'tcx>, PermissionsData>>
   for PermissionsDomain<'tcx>

--- a/crates/aquascope/src/mir/utils.rs
+++ b/crates/aquascope/src/mir/utils.rs
@@ -2,7 +2,7 @@
 
 use flowistry::mir::utils::PlaceExt as FlowistryPlaceExt;
 use rustc_data_structures::captures::Captures;
-use rustc_hir::{def_id::DefId, lang_items::LangItem};
+use rustc_hir::def_id::DefId;
 use rustc_infer::infer::TyCtxtInferExt;
 use rustc_middle::{
   mir::{Body, Place},
@@ -144,9 +144,8 @@ impl<'tcx> TyExt<'tcx> for Ty<'tcx> {
   }
 
   fn is_copyable(&self, tcx: TyCtxt<'tcx>, param_env: ParamEnv<'tcx>) -> bool {
-    log::debug!("Checking if {self:?} implements Copy");
-    let copy_def_id = tcx.require_lang_item(LangItem::Copy, None);
-    self.does_implement_trait(tcx, param_env, copy_def_id)
+    let ty = tcx.erase_regions(*self);
+    ty.is_copy_modulo_regions(tcx, param_env)
   }
 }
 

--- a/crates/aquascope/tests/boundaries/read_on_copy_0.test
+++ b/crates/aquascope/tests/boundaries/read_on_copy_0.test
@@ -1,0 +1,14 @@
+#[derive(Copy, Clone)]
+struct S(i32);
+
+impl S {
+  fn consume(self) {}
+}
+
+fn main() {
+  let s = &S(0);
+  s.consume();
+  s.consume();
+  s.consume();
+  s.consume();
+}

--- a/crates/aquascope/tests/refinement/refine_basic_4.test
+++ b/crates/aquascope/tests/refinement/refine_basic_4.test
@@ -7,15 +7,15 @@ fn main() {
 
   let _a = &`[z ---]`;
   let _a = &`[x R-D]`;
-  let _a = &`[*x RWD]`;
+  let _a = &`[*x RW-]`;
 
   let y: &i32 = &*x;
 
   let _a = &`[z ---]`;
   let _a = &`[x R--]`;
-  let _a = &`[*x R-D]`;
+  let _a = &`[*x R-0]`;
   let _a = &`[y R-D]`;
-  let _a = &`[*y R-D]`;
+  let _a = &`[*y R--]`;
 
   println!("{} = {}", x, *y);
 }

--- a/crates/aquascope/tests/refinement/refine_basic_5.test
+++ b/crates/aquascope/tests/refinement/refine_basic_5.test
@@ -7,15 +7,15 @@ fn main() {
 
   let _a = &`[z ---]`;
   let _a = &`[x R-D]`;
-  let _a = &`[*x RWD]`;
+  let _a = &`[*x RW-]`;
 
   let y: &i32 = &*x;
 
   let _a = &`[z ---]`;
   let _a = &`[x R--]`;
-  let _a = &`[*x R-D]`;
+  let _a = &`[*x R--]`;
   let _a = &`[y R-D]`;
-  let _a = &`[*y R-D]`;
+  let _a = &`[*y R--]`;
 
   *x += 1; // ERROR: *x doesn't have 'W' permissions
 
@@ -27,9 +27,9 @@ fn main() {
 
   let _a = &`[z ---]`;
   let _a = &`[x R-D]`;
-  let _a = &`[*x RWD]`;
+  let _a = &`[*x RW-]`;
   let _a = &`[y R-D]`;
-  let _a = &`[*y R-D]`;
+  let _a = &`[*y R--]`;
 
   println!("{} = {}", x, *y);
 }

--- a/crates/aquascope/tests/refinement/refine_field_2.test
+++ b/crates/aquascope/tests/refinement/refine_field_2.test
@@ -12,13 +12,13 @@ fn func(res: &mut TestResult) {
 
     let _a = &`[*res R--]`;
     let _a = &`[res.scores R--]`;
-    let _a = &`[res.min R-D]`;
+    let _a = &`[res.min R--]`;
 
     for score in res.scores.iter_mut() {
 
       let _a = &`[*res ---]`;
       let _a = &`[res.scores ---]`;
-      let _a = &`[res.min R-D]`;
+      let _a = &`[res.min R--]`;
 
       *score = (*score).max(*min);
     }
@@ -26,5 +26,5 @@ fn func(res: &mut TestResult) {
 
   let _a = &`[*res RW-]`;
   let _a = &`[res.scores RW-]`;
-  let _a = &`[res.min RWD]`;
+  let _a = &`[res.min RW-]`;
 }

--- a/crates/aquascope/tests/snapshots/boundaries__add_big_strings@closure_1.test.snap
+++ b/crates/aquascope/tests/snapshots/boundaries__add_big_strings@closure_1.test.snap
@@ -36,7 +36,7 @@ description: add_big_strings@closure_1.test
   expected:
     read: true
     write: false
-    drop: true
+    drop: false
   actual:
     type_droppable: true
     type_writeable: false

--- a/crates/aquascope/tests/snapshots/boundaries__bx@box.test.snap
+++ b/crates/aquascope/tests/snapshots/boundaries__bx@box.test.snap
@@ -16,5 +16,5 @@ description: bx@box.test
     permissions:
       read: true
       write: false
-      drop: true
+      drop: false
 

--- a/crates/aquascope/tests/snapshots/boundaries__get_first@type-driven-flows.test.snap
+++ b/crates/aquascope/tests/snapshots/boundaries__get_first@type-driven-flows.test.snap
@@ -38,7 +38,7 @@ description: get_first@type-driven-flows.test
     permissions:
       read: true
       write: false
-      drop: true
+      drop: false
   expecting_flow:
     is_violation: false
     flow_context:

--- a/crates/aquascope/tests/snapshots/boundaries__get_first_constrained@type-driven-flows.test.snap
+++ b/crates/aquascope/tests/snapshots/boundaries__get_first_constrained@type-driven-flows.test.snap
@@ -31,7 +31,7 @@ description: get_first_constrained@type-driven-flows.test
     permissions:
       read: true
       write: false
-      drop: true
+      drop: false
   expecting_flow:
     is_violation: false
     flow_context:

--- a/crates/aquascope/tests/snapshots/boundaries__get_first_specified@type-driven-flows.test.snap
+++ b/crates/aquascope/tests/snapshots/boundaries__get_first_specified@type-driven-flows.test.snap
@@ -38,7 +38,7 @@ description: get_first_specified@type-driven-flows.test
     permissions:
       read: true
       write: false
-      drop: true
+      drop: false
   expecting_flow:
     is_violation: false
     flow_context:

--- a/crates/aquascope/tests/snapshots/boundaries__main@assignop_path_resolution.test.snap
+++ b/crates/aquascope/tests/snapshots/boundaries__main@assignop_path_resolution.test.snap
@@ -21,7 +21,7 @@ description: main@assignop_path_resolution.test
   expected:
     read: true
     write: false
-    drop: true
+    drop: false
   actual:
     type_droppable: false
     type_writeable: false
@@ -31,7 +31,7 @@ description: main@assignop_path_resolution.test
     permissions:
       read: true
       write: false
-      drop: true
+      drop: false
 - location: 200
   expected:
     read: true
@@ -51,7 +51,7 @@ description: main@assignop_path_resolution.test
   expected:
     read: true
     write: false
-    drop: true
+    drop: false
   actual:
     type_droppable: true
     type_writeable: true
@@ -63,12 +63,12 @@ description: main@assignop_path_resolution.test
     permissions:
       read: true
       write: false
-      drop: true
+      drop: false
 - location: 209
   expected:
     read: true
     write: false
-    drop: true
+    drop: false
   actual:
     type_droppable: true
     type_writeable: false
@@ -83,7 +83,7 @@ description: main@assignop_path_resolution.test
   expected:
     read: true
     write: false
-    drop: true
+    drop: false
   actual:
     type_droppable: false
     type_writeable: false
@@ -93,5 +93,5 @@ description: main@assignop_path_resolution.test
     permissions:
       read: true
       write: false
-      drop: true
+      drop: false
 

--- a/crates/aquascope/tests/snapshots/boundaries__main@read_on_copy_0.test.snap
+++ b/crates/aquascope/tests/snapshots/boundaries__main@read_on_copy_0.test.snap
@@ -1,45 +1,8 @@
 ---
 source: crates/aquascope/tests/boundaries.rs
-description: add_ref@add_ref.test
+description: main@read_on_copy_0.test
 ---
-- location: 68
-  expected:
-    read: true
-    write: false
-    drop: false
-  actual:
-    type_droppable: true
-    type_writeable: false
-    type_copyable: true
-    is_live: true
-    path_uninitialized: false
-    permissions:
-      read: true
-      write: false
-      drop: true
-- location: 74
-  expected:
-    read: true
-    write: true
-    drop: false
-  actual:
-    type_droppable: false
-    type_writeable: true
-    type_copyable: false
-    is_live: true
-    path_uninitialized: false
-    permissions:
-      read: true
-      write: true
-      drop: false
-  expecting_flow:
-    is_violation: false
-    flow_context:
-      char_start: 73
-      char_end: 83
-      filename: 0
-    kind: Ok
-- location: 80
+- location: 105
   expected:
     read: true
     write: false
@@ -54,11 +17,49 @@ description: add_ref@add_ref.test
       read: true
       write: false
       drop: false
-  expecting_flow:
-    is_violation: true
-    flow_context:
-      char_start: 73
-      char_end: 83
-      filename: 0
-    kind: LocalOutlivesUniversal
+- location: 120
+  expected:
+    read: true
+    write: false
+    drop: false
+  actual:
+    type_droppable: false
+    type_writeable: false
+    type_copyable: true
+    is_live: true
+    path_uninitialized: false
+    permissions:
+      read: true
+      write: false
+      drop: false
+- location: 135
+  expected:
+    read: true
+    write: false
+    drop: false
+  actual:
+    type_droppable: false
+    type_writeable: false
+    type_copyable: true
+    is_live: true
+    path_uninitialized: false
+    permissions:
+      read: true
+      write: false
+      drop: false
+- location: 150
+  expected:
+    read: true
+    write: false
+    drop: false
+  actual:
+    type_droppable: false
+    type_writeable: false
+    type_copyable: true
+    is_live: true
+    path_uninitialized: false
+    permissions:
+      read: true
+      write: false
+      drop: false
 

--- a/crates/aquascope/tests/snapshots/boundaries__missing_constraint@missing_constraint.test.snap
+++ b/crates/aquascope/tests/snapshots/boundaries__missing_constraint@missing_constraint.test.snap
@@ -16,7 +16,7 @@ description: missing_constraint@missing_constraint.test
     permissions:
       read: true
       write: false
-      drop: true
+      drop: false
   expecting_flow:
     is_violation: true
     flow_context:

--- a/crates/aquascope/tests/snapshots/boundaries__mut_bx@box.test.snap
+++ b/crates/aquascope/tests/snapshots/boundaries__mut_bx@box.test.snap
@@ -16,5 +16,5 @@ description: mut_bx@box.test
     permissions:
       read: true
       write: true
-      drop: true
+      drop: false
 

--- a/crates/aquascope/tests/snapshots/boundaries__mut_slice@array.test.snap
+++ b/crates/aquascope/tests/snapshots/boundaries__mut_slice@array.test.snap
@@ -16,5 +16,5 @@ description: mut_slice@array.test
     permissions:
       read: true
       write: true
-      drop: true
+      drop: false
 

--- a/crates/aquascope/tests/snapshots/boundaries__slice@array.test.snap
+++ b/crates/aquascope/tests/snapshots/boundaries__slice@array.test.snap
@@ -16,5 +16,5 @@ description: slice@array.test
     permissions:
       read: true
       write: false
-      drop: true
+      drop: false
 

--- a/crates/aquascope/tests/snapshots/boundaries__test@deref_assign_0.test.snap
+++ b/crates/aquascope/tests/snapshots/boundaries__test@deref_assign_0.test.snap
@@ -16,5 +16,5 @@ description: test@deref_assign_0.test
     permissions:
       read: true
       write: true
-      drop: true
+      drop: false
 

--- a/crates/aquascope/tests/snapshots/stepper__add_ref@if_2.test.snap
+++ b/crates/aquascope/tests/snapshots/stepper__add_ref@if_2.test.snap
@@ -32,8 +32,8 @@ description: add_ref@if_2.test
             type: None
             value: false
           drop:
-            type: High
-            value: true
+            type: None
+            value: false
     - - "*v"
       - is_live:
           type: High
@@ -407,7 +407,8 @@ description: add_ref@if_2.test
             type: None
             value: false
           drop:
-            type: Low
+            type: None
+            value: false
     - - n
       - is_live:
           type: Low

--- a/crates/aquascope/tests/snapshots/stepper__ascii_capitalize@if_3.test.snap
+++ b/crates/aquascope/tests/snapshots/stepper__ascii_capitalize@if_3.test.snap
@@ -95,8 +95,8 @@ description: ascii_capitalize@if_3.test
             type: None
             value: false
           drop:
-            type: High
-            value: true
+            type: None
+            value: false
     - - "*v"
       - is_live:
           type: None
@@ -220,7 +220,8 @@ description: ascii_capitalize@if_3.test
             type: None
             value: false
           drop:
-            type: Low
+            type: None
+            value: false
     - - "*v"
       - is_live:
           type: None
@@ -454,7 +455,8 @@ description: ascii_capitalize@if_3.test
             type: None
             value: false
           drop:
-            type: Low
+            type: None
+            value: false
     - - "*v"
       - is_live:
           type: None

--- a/crates/aquascope/tests/snapshots/stepper__foo@if_4.test.snap
+++ b/crates/aquascope/tests/snapshots/stepper__foo@if_4.test.snap
@@ -64,8 +64,8 @@ description: foo@if_4.test
             type: High
             value: true
           drop:
-            type: High
-            value: true
+            type: None
+            value: false
     - - a
       - is_live:
           type: High
@@ -274,7 +274,8 @@ description: foo@if_4.test
           write:
             type: Low
           drop:
-            type: Low
+            type: None
+            value: false
     - - a
       - is_live:
           type: Low
@@ -330,7 +331,8 @@ description: foo@if_4.test
           write:
             type: Low
           drop:
-            type: Low
+            type: None
+            value: false
     - - a
       - is_live:
           type: Low

--- a/crates/aquascope/tests/snapshots/stepper__foo@match_0.test.snap
+++ b/crates/aquascope/tests/snapshots/stepper__foo@match_0.test.snap
@@ -64,8 +64,8 @@ description: foo@match_0.test
             type: High
             value: true
           drop:
-            type: High
-            value: true
+            type: None
+            value: false
     - - a
       - is_live:
           type: High
@@ -274,7 +274,8 @@ description: foo@match_0.test
           write:
             type: Low
           drop:
-            type: Low
+            type: None
+            value: false
     - - a
       - is_live:
           type: Low
@@ -330,7 +331,8 @@ description: foo@match_0.test
           write:
             type: Low
           drop:
-            type: Low
+            type: None
+            value: false
     - - a
       - is_live:
           type: Low

--- a/crates/aquascope/tests/snapshots/stepper__foo@match_1.test.snap
+++ b/crates/aquascope/tests/snapshots/stepper__foo@match_1.test.snap
@@ -64,8 +64,8 @@ description: foo@match_1.test
             type: High
             value: true
           drop:
-            type: High
-            value: true
+            type: None
+            value: false
     - - a
       - is_live:
           type: High
@@ -274,7 +274,8 @@ description: foo@match_1.test
           write:
             type: Low
           drop:
-            type: Low
+            type: None
+            value: false
     - - a
       - is_live:
           type: Low

--- a/crates/aquascope/tests/snapshots/stepper__main@linear_0.test.snap
+++ b/crates/aquascope/tests/snapshots/stepper__main@linear_0.test.snap
@@ -95,8 +95,8 @@ description: main@linear_0.test
             type: High
             value: true
           drop:
-            type: High
-            value: true
+            type: None
+            value: false
     - - x
       - is_live:
           type: Low
@@ -212,7 +212,8 @@ description: main@linear_0.test
           write:
             type: Low
           drop:
-            type: Low
+            type: None
+            value: false
     - - z
       - is_live:
           type: Low

--- a/crates/aquascope/tests/snapshots/stepper__reverse@vec_0.test.snap
+++ b/crates/aquascope/tests/snapshots/stepper__reverse@vec_0.test.snap
@@ -158,8 +158,8 @@ description: reverse@vec_0.test
             type: High
             value: true
           drop:
-            type: High
-            value: true
+            type: None
+            value: false
     - - "*v"
       - is_live:
           type: None


### PR DESCRIPTION
Updates the boundaries analysis to only require a path to have Own permissions when its type does implement Copy. Permissions no longer give a path Own when it is copyable, rather, it follows the normal semantics.

I checked all of the tests by hand, but it would still be wise to check all the book examples before regenerating them. This might also make a substantial change to warrant a bump to `v0.2.0`. For this, we probably want to tag the current version at 0.1.4 to get the recent changes in there first.