### PR TITLE
Replace Flowistry dependency with rustc-utils

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,8 +3,9 @@ name: aquascope
 on:
   push:
     branches:
-      - main
-      - dev
+      - "**"
+    tags-ignore:
+      - "v*"
   pull_request:
     branches:
       - "**"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,3 @@ opt-level = 3
 
 [profile.dev.package.similar]
 opt-level = 3
-
-[patch.crates-io]
-flowistry = { git = "https://github.com/willcrichton/flowistry", rev = "a156ab9839b9e84fe9e178ce16937e98d13613b5" }

--- a/crates/aquascope/Cargo.toml
+++ b/crates/aquascope/Cargo.toml
@@ -15,13 +15,12 @@ publish = false
 rustc_private = true
 
 [features]
-testing = ["lazy_static", "insta", "flowistry/test"]
+testing = ["lazy_static", "insta", "rustc-utils/test"]
 
 [dependencies]
 anyhow = "1.0.0"
 log = "0.4"
 itertools = "0.10.5"
-flowistry = "0.5.35"
 serde = { version = "1.0", features = ["derive"] }
 ts-rs = "6.2"
 regex = "1"
@@ -34,6 +33,10 @@ aquascope_workspace_utils = { version = "0.1", path = "../aquascope_workspace_ut
 # testing
 lazy_static = { version = "1.4", optional = true }
 insta = { version = "1.22.0", features = ["json", "yaml", "redactions"], optional = true }
+
+[dependencies.rustc-utils]
+git = "https://github.com/cognitive-engineering-lab/rustc-plugin"
+tag = "nightly-2023-04-12-v0.1.2"
 
 [dev-dependencies]
 aquascope = { path = ".", features = ["testing"] }

--- a/crates/aquascope/src/analysis/boundaries/mod.rs
+++ b/crates/aquascope/src/analysis/boundaries/mod.rs
@@ -6,7 +6,6 @@ pub(crate) mod path_visitor;
 
 use anyhow::Result;
 use either::Either;
-use flowistry::mir::utils::{OperandExt, SpanExt};
 use path_visitor::get_path_boundaries;
 use rustc_hir::HirId;
 use rustc_middle::{
@@ -14,6 +13,7 @@ use rustc_middle::{
   ty::{adjustment::AutoBorrowMutability, TyCtxt},
 };
 use rustc_span::Span;
+use rustc_utils::{OperandExt, SpanExt};
 use serde::Serialize;
 use smallvec::{smallvec, SmallVec};
 use ts_rs::TS;
@@ -329,7 +329,7 @@ fn paths_at_hir_id<'a, 'tcx: 'a>(
   macro_rules! maybe_in_op {
     ($loc:expr, $op:expr) => {
       $op
-        .to_place()
+        .as_place()
         .and_then(|p| p.is_source_visible(tcx, body).then_some(p))
         .map(|p| smallvec![($loc, p)])
         .unwrap_or(smallvec![])

--- a/crates/aquascope/src/analysis/ir_mapper/mod.rs
+++ b/crates/aquascope/src/analysis/ir_mapper/mod.rs
@@ -6,7 +6,6 @@ pub(crate) mod post_dominators;
 // pub(crate) mod region_name;
 
 pub(crate) use body_graph::CleanedBody;
-use flowistry::mir::utils::BodyExt;
 pub(crate) use mir_locations::MirOrderedLocations;
 use post_dominators::AllPostDominators;
 use rustc_data_structures::{
@@ -20,6 +19,7 @@ use rustc_middle::{
   },
   ty::TyCtxt,
 };
+use rustc_utils::BodyExt;
 
 pub struct IRMapper<'a, 'tcx> {
   pub(crate) cleaned_graph: CleanedBody<'a, 'tcx>,

--- a/crates/aquascope/src/analysis/ir_mapper/post_dominators.rs
+++ b/crates/aquascope/src/analysis/ir_mapper/post_dominators.rs
@@ -1,9 +1,9 @@
-use flowistry::mir::control_dependencies::PostDominators;
 use rustc_data_structures::graph::*;
 use rustc_index::{
   bit_set::{HybridBitSet, SparseBitMatrix},
   vec::Idx,
 };
+use rustc_utils::mir::control_dependencies::PostDominators;
 
 /// Computes the intersection of the post-dominators across all exits
 /// to a graph.

--- a/crates/aquascope/src/analysis/mod.rs
+++ b/crates/aquascope/src/analysis/mod.rs
@@ -17,13 +17,6 @@ use std::{
 pub use boundaries::compute_permission_boundaries;
 use boundaries::PermissionsBoundary;
 pub use find_bindings::find_bindings;
-use flowistry::{
-  mir::{
-    borrowck_facts::get_body_with_borrowck_facts,
-    utils::{BodyExt, SpanExt},
-  },
-  source_map::CharRange,
-};
 use ir_mapper::{GatherMode, IRMapper};
 use permissions::{
   Loan, Move, PermissionsCtxt, Point, RefinementRegion, Refiner,
@@ -33,6 +26,9 @@ use rustc_data_structures::fx::FxHashMap;
 use rustc_hir::BodyId;
 use rustc_middle::ty::TyCtxt;
 use rustc_span::{BytePos, Span};
+use rustc_utils::{
+  mir::borrowck_facts, source_map::range::CharRange, BodyExt, SpanExt,
+};
 use serde::Serialize;
 pub use stepper::compute_permission_steps;
 use stepper::PermissionsLineDisplay;
@@ -277,7 +273,7 @@ pub struct AnalysisOutput {
 impl<'a, 'tcx: 'a> AquascopeAnalysis<'a, 'tcx> {
   pub fn new(tcx: TyCtxt<'tcx>, body_id: BodyId) -> Self {
     let def_id = tcx.hir().body_owner_def_id(body_id);
-    let bwf = get_body_with_borrowck_facts(tcx, def_id);
+    let bwf = borrowck_facts::get_body_with_borrowck_facts(tcx, def_id);
     let permissions = compute_permissions(tcx, body_id, bwf);
     let body = &permissions.body_with_facts.body;
 

--- a/crates/aquascope/src/analysis/permissions/context.rs
+++ b/crates/aquascope/src/analysis/permissions/context.rs
@@ -1,4 +1,3 @@
-use flowistry::mir::utils::{PlaceExt, SpanExt};
 use polonius_engine::{AllFacts, FactTypes, Output as PEOutput};
 use rustc_borrowck::{
   borrow_set::{BorrowData, BorrowSet},
@@ -13,6 +12,7 @@ use rustc_middle::{
 };
 use rustc_mir_dataflow::move_paths::MoveData;
 use rustc_span::Span;
+use rustc_utils::{PlaceExt, SpanExt};
 use smallvec::{smallvec, SmallVec};
 
 use crate::{

--- a/crates/aquascope/src/analysis/permissions/output.rs
+++ b/crates/aquascope/src/analysis/permissions/output.rs
@@ -9,7 +9,6 @@
 use std::time::Instant;
 
 use datafrog::{Iteration, Relation, RelationLeaper, ValueFilter};
-use flowistry::mir::utils::PlaceExt;
 use polonius_engine::{Algorithm, FactTypes, Output as PEOutput};
 use rustc_borrowck::{borrow_set::BorrowSet, consumers::BodyWithBorrowckFacts};
 use rustc_data_structures::fx::{FxHashMap as HashMap, FxHashSet as HashSet};
@@ -20,6 +19,7 @@ use rustc_middle::{
   ty::TyCtxt,
 };
 use rustc_mir_dataflow::move_paths::MoveData;
+use rustc_utils::PlaceExt;
 
 use super::{
   context::PermissionsCtxt,

--- a/crates/aquascope/src/analysis/stepper/find_steps.rs
+++ b/crates/aquascope/src/analysis/stepper/find_steps.rs
@@ -206,7 +206,6 @@
 //!   and `else`, or if there are multiple returns, the algorithm also fails.
 
 use anyhow::{bail, Result};
-use flowistry::mir::utils::{PlaceExt as FlowistryPlaceExt, SpanExt};
 use rustc_data_structures::{self, fx::FxHashMap as HashMap};
 use rustc_hir::{
   self as hir,
@@ -218,6 +217,7 @@ use rustc_middle::{
   mir::{self, Local, Location, Place},
 };
 use rustc_span::Span;
+use rustc_utils::{PlaceExt as FlowistryPlaceExt, SpanExt};
 
 use super::{
   segment_tree::{MirSegment, SegmentSearchResult, SegmentTree, SplitType},

--- a/crates/aquascope/src/interpreter/mapper.rs
+++ b/crates/aquascope/src/interpreter/mapper.rs
@@ -6,12 +6,12 @@ use std::{
 };
 
 use either::Either;
-use flowistry::mir::utils::BodyExt;
 use itertools::Itertools;
 use miri::InterpCx;
 use rustc_hir::{intravisit::Visitor, Body, Expr, ExprKind, HirId, Stmt};
 use rustc_middle::{mir::Location, ty::InstanceDef};
 use rustc_span::{BytePos, Span};
+use rustc_utils::BodyExt;
 
 use super::step::{MFrame, MStack, MStep, MTrace, MirLoc};
 use crate::analysis::ir_mapper::{GatherDepth, GatherMode, IRMapper};

--- a/crates/aquascope/src/interpreter/mod.rs
+++ b/crates/aquascope/src/interpreter/mod.rs
@@ -2,13 +2,13 @@
 
 use anyhow::Result;
 use either::Either;
-use flowistry::mir::utils::SpanExt;
 use rustc_data_structures::fx::FxIndexMap;
 use rustc_hir::def_id::LocalDefId;
 use rustc_middle::{
   mir::{Body, BorrowCheckResult},
   ty::{self, query::Providers, TyCtxt},
 };
+use rustc_utils::{source_map::range::CharRange, SpanExt};
 
 mod mapper;
 mod miri_utils;
@@ -62,9 +62,7 @@ pub(crate) fn interpret(tcx: TyCtxt) -> Result<MTrace<Range>> {
       Either::Left(node_id) => hir.span(node_id).as_local(outer_span)?,
       Either::Right(span) => span.as_local(outer_span)?,
     };
-    let range =
-      flowistry::source_map::CharRange::from_span(span, tcx.sess.source_map())
-        .unwrap();
+    let range = CharRange::from_span(span, tcx.sess.source_map()).unwrap();
     Some(Range::from(range))
   });
 

--- a/crates/aquascope/src/interpreter/step.rs
+++ b/crates/aquascope/src/interpreter/step.rs
@@ -4,7 +4,6 @@ use std::{cell::RefCell, cmp::Ordering, collections::HashMap};
 
 use anyhow::{anyhow, bail, Context, Result};
 use either::Either;
-use flowistry::mir::utils::PlaceExt;
 use miri::{
   AllocId, AllocMap, AllocRange, Frame, Immediate, InterpCx, InterpError,
   InterpErrorInfo, InterpResult, LocalState, LocalValue, Machine, MiriConfig,
@@ -18,6 +17,7 @@ use rustc_middle::{
 };
 use rustc_session::CtfeBacktrace;
 use rustc_span::Span;
+use rustc_utils::{source_map::range::CharRange, PlaceExt};
 use serde::{Deserialize, Serialize};
 use ts_rs::TS;
 
@@ -155,7 +155,7 @@ impl<'mir, 'tcx> VisEvaluator<'mir, 'tcx> {
 
     let tcx = *self.ecx.tcx;
     let body_span = Range::from(
-      flowistry::source_map::CharRange::from_span(
+      CharRange::from_span(
         body_span(tcx, frame.instance.def_id(), BodySpanType::Whole),
         tcx.sess.source_map(),
       )

--- a/crates/aquascope/src/lib.rs
+++ b/crates/aquascope/src/lib.rs
@@ -89,6 +89,7 @@ pub mod mir;
 #[cfg(feature = "testing")]
 pub mod test_utils;
 
+use rustc_utils::source_map::range::CharRange;
 use serde::{Deserialize, Serialize};
 use ts_rs::TS;
 
@@ -103,8 +104,8 @@ pub struct Range {
   pub filename: usize,
 }
 
-impl From<flowistry::source_map::CharRange> for Range {
-  fn from(i: flowistry::source_map::CharRange) -> Self {
+impl From<CharRange> for Range {
+  fn from(i: CharRange) -> Self {
     Range {
       char_start: i.start.0,
       char_end: i.end.0,

--- a/crates/aquascope/src/mir/utils.rs
+++ b/crates/aquascope/src/mir/utils.rs
@@ -1,6 +1,5 @@
 //! A smattering of utilities not yet (or that won't ever be) upstreamed to Flowistry.
 
-use flowistry::mir::utils::PlaceExt as FlowistryPlaceExt;
 use rustc_data_structures::captures::Captures;
 use rustc_hir::def_id::DefId;
 use rustc_infer::infer::TyCtxtInferExt;
@@ -9,6 +8,7 @@ use rustc_middle::{
   ty::{self, subst::GenericArgKind, ParamEnv, Region, RegionVid, Ty, TyCtxt},
 };
 use rustc_trait_selection::infer::InferCtxtExt;
+use rustc_utils::PlaceExt as FlowistryPlaceExt;
 use smallvec::SmallVec;
 
 //------------------------------------------------

--- a/crates/aquascope_front/Cargo.toml
+++ b/crates/aquascope_front/Cargo.toml
@@ -18,7 +18,6 @@ rustc_private = true
 aquascope = {version = "0.1", path = "../aquascope"}
 anyhow = "1"
 log = "0.4"
-flowistry = "0.5.35"
 serde = {version = "1", features = ["derive"]}
 serde_json = "1"
 ts-rs = "6.2"
@@ -31,4 +30,8 @@ clap = {version = "3.1", default-features = false, features = ["std", "derive"]}
 
 [dependencies.rustc-plugin]
 git = "https://github.com/cognitive-engineering-lab/rustc-plugin"
-tag = "nightly-2023-04-12-v0.1.1"
+tag = "nightly-2023-04-12-v0.1.2"
+
+[dependencies.rustc-utils]
+git = "https://github.com/cognitive-engineering-lab/rustc-plugin"
+tag = "nightly-2023-04-12-v0.1.2"

--- a/crates/aquascope_front/src/plugin.rs
+++ b/crates/aquascope_front/src/plugin.rs
@@ -16,15 +16,12 @@ use aquascope::{
   Range,
 };
 use clap::{Parser, Subcommand};
-use flowistry::{
-  mir::borrowck_facts::{self, NO_SIMPLIFY},
-  source_map::find_bodies,
-};
 use fluid_let::fluid_set;
 use rustc_hir::BodyId;
 use rustc_interface::interface::Result as RustcResult;
 use rustc_middle::ty::TyCtxt;
 use rustc_plugin::{CrateFilter, RustcPlugin, RustcPluginArgs, Utf8Path};
+use rustc_utils::{mir::borrowck_facts, source_map::find_bodies::find_bodies};
 use serde::{self, Deserialize, Serialize};
 
 const VERSION: &str = env!("CARGO_PKG_VERSION");
@@ -220,7 +217,6 @@ struct AquascopeCallbacks<A: AquascopeAnalysis> {
 
 impl<A: AquascopeAnalysis> rustc_driver::Callbacks for AquascopeCallbacks<A> {
   fn config(&mut self, config: &mut rustc_interface::Config) {
-    NO_SIMPLIFY.store(true, std::sync::atomic::Ordering::SeqCst);
     config.override_queries = Some(borrowck_facts::override_queries);
   }
 


### PR DESCRIPTION
Only semantic change is that `SIMPLIFY_MIR` has been removed. By default, the MIR is left unchanged. Flowistry now specially enables a flag to turn on simplifications.

@gavinleroy: is there any functionality in Aquascope that you want to migrate to rustc-utils?