### PR TITLE
Convert CharPos to number in renderInterpreter.

### DIFF
--- a/frontend/packages/aquascope-editor/src/editor-utils/interpreter.tsx
+++ b/frontend/packages/aquascope-editor/src/editor-utils/interpreter.tsx
@@ -814,14 +814,14 @@ export function renderInterpreter(
 ) {
   let root = ReactDOM.createRoot(container);
   let marks = annotations?.state_locations || [];
-  let widgetRanges;
+  let widgetRanges: number[];
   if (marks.length > 0) {
     let [sortedMarks, filteredSteps] = filterSteps(view, trace.steps, marks);
     widgetRanges = sortedMarks;
     trace.steps = filteredSteps;
   } else {
     widgetRanges = trace.steps.map(
-      step => _.last(step.stack.frames)!.location.end
+      step => linecolToPosition(_.last(step.stack.frames)!.location.end, view.state.doc)
     );
   }
 

--- a/frontend/packages/aquascope-editor/src/editor-utils/interpreter.tsx
+++ b/frontend/packages/aquascope-editor/src/editor-utils/interpreter.tsx
@@ -379,7 +379,7 @@ let FrameView = ({
   frame: MFrame<CharRange>;
 }) => {
   let code = useContext(CodeContext);
-  let snippet = codeRange(code, frame.location);
+  let snippet = codeRange(code!, frame.location);
   return (
     <div className="frame">
       <Header className="frame-header">{frame.name}</Header>
@@ -814,14 +814,14 @@ export function renderInterpreter(
 ) {
   let root = ReactDOM.createRoot(container);
   let marks = annotations?.state_locations || [];
-  let widgetRanges: number[];
+  let widgetRanges;
   if (marks.length > 0) {
     let [sortedMarks, filteredSteps] = filterSteps(view, trace.steps, marks);
     widgetRanges = sortedMarks;
     trace.steps = filteredSteps;
   } else {
-    widgetRanges = trace.steps.map(
-      step => linecolToPosition(_.last(step.stack.frames)!.location.end, view.state.doc)
+    widgetRanges = trace.steps.map(step =>
+      linecolToPosition(_.last(step.stack.frames)!.location.end, view.state.doc)
     );
   }
 

--- a/frontend/packages/aquascope-embed/package.json
+++ b/frontend/packages/aquascope-embed/package.json
@@ -11,6 +11,8 @@
     "@codemirror/view": "^6.4.0",
     "@floating-ui/react-dom": "^1.3.0",
     "@lezer/highlight": "^1.1.3",
+    "@types/react": "^18.0.26",
+    "@types/react-dom": "^18.2.0",
     "@vitejs/plugin-react": "^4.0.3",
     "aquascope-editor": "workspace:*",
     "puppeteer": "^19.6.0",

--- a/frontend/packages/aquascope-embed/src/main.tsx
+++ b/frontend/packages/aquascope-embed/src/main.tsx
@@ -111,7 +111,7 @@ let BugReporter = () => (
   <ContextProvider title={"Report a bug"} buttonText={"🐞"}>
     {close => {
       let code = useContext(CodeContext);
-      let onSubmit: React.FormEventHandler<HTMLFormElement> = event => {
+      let onSubmit: React.FormEventHandler<HTMLFormElement> = (event: any) => {
         let data = new FormData(event.target as any);
         let feedback = data.get("feedback")!.toString();
         window.telemetry!.log("aquascopeBug", { code, feedback });

--- a/frontend/packages/aquascope-standalone/tests/standalone.test.ts
+++ b/frontend/packages/aquascope-standalone/tests/standalone.test.ts
@@ -4,7 +4,7 @@ import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest";
 
 const permStackSelector = ".permission-stack";
 const permStepSelector = ".step-widget-container";
-const interpSelector = ".interpreter";
+const _interpSelector = ".interpreter";
 
 describe("Aquascope Standalone", () => {
   let browser: Browser;

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -40,7 +40,7 @@ importers:
         version: 5.1.6
       vite:
         specifier: ^4.4.4
-        version: 4.4.4(@types/node@20.4.2)
+        version: 4.4.4(@types/node@20.4.2)(sass@1.63.6)
       vitest:
         specifier: ^0.33.0
         version: 0.33.0
@@ -108,6 +108,12 @@ importers:
       '@lezer/highlight':
         specifier: ^1.1.3
         version: 1.1.6
+      '@types/react':
+        specifier: ^18.0.26
+        version: 18.0.26
+      '@types/react-dom':
+        specifier: ^18.2.0
+        version: 18.2.0
       '@vitejs/plugin-react':
         specifier: ^4.0.3
         version: 4.0.3(vite@4.4.4)
@@ -1035,6 +1041,12 @@ packages:
 
   /@types/react-dom@18.0.9:
     resolution: {integrity: sha512-qnVvHxASt/H7i+XG1U1xMiY5t+IHcPGUK7TDMDzom08xa7e86eCeKOiLZezwCKVxJn6NEiiy2ekgX8aQssjIKg==}
+    dependencies:
+      '@types/react': 18.0.26
+    dev: true
+
+  /@types/react-dom@18.2.0:
+    resolution: {integrity: sha512-8yQrvS6sMpSwIovhPOwfyNf2Wz6v/B62LFSVYQ85+Rq3tLsBIG7rP5geMxaijTUxSkrO6RzN/IRuIAADYQsleA==}
     dependencies:
       '@types/react': 18.0.26
     dev: true
@@ -3810,7 +3822,7 @@ packages:
       mlly: 1.4.0
       pathe: 1.1.1
       picocolors: 1.0.0
-      vite: 4.4.4(@types/node@20.4.2)
+      vite: 4.4.4(@types/node@20.4.2)(sass@1.63.6)
     transitivePeerDependencies:
       - '@types/node'
       - less
@@ -3820,42 +3832,6 @@ packages:
       - sugarss
       - supports-color
       - terser
-    dev: true
-
-  /vite@4.4.4(@types/node@20.4.2):
-    resolution: {integrity: sha512-4mvsTxjkveWrKDJI70QmelfVqTm+ihFAb6+xf4sjEU2TmUCTlVX87tmg/QooPEMQb/lM9qGHT99ebqPziEd3wg==}
-    engines: {node: ^14.18.0 || >=16.0.0}
-    hasBin: true
-    peerDependencies:
-      '@types/node': '>= 14'
-      less: '*'
-      lightningcss: ^1.21.0
-      sass: '*'
-      stylus: '*'
-      sugarss: '*'
-      terser: ^5.4.0
-    peerDependenciesMeta:
-      '@types/node':
-        optional: true
-      less:
-        optional: true
-      lightningcss:
-        optional: true
-      sass:
-        optional: true
-      stylus:
-        optional: true
-      sugarss:
-        optional: true
-      terser:
-        optional: true
-    dependencies:
-      '@types/node': 20.4.2
-      esbuild: 0.18.13
-      postcss: 8.4.26
-      rollup: 3.26.2
-    optionalDependencies:
-      fsevents: 2.3.2
     dev: true
 
   /vite@4.4.4(@types/node@20.4.2)(sass@1.63.6):
@@ -3947,7 +3923,7 @@ packages:
       strip-literal: 1.0.1
       tinybench: 2.5.0
       tinypool: 0.6.0
-      vite: 4.4.4(@types/node@20.4.2)
+      vite: 4.4.4(@types/node@20.4.2)(sass@1.63.6)
       vite-node: 0.33.0(@types/node@20.4.2)
       why-is-node-running: 2.2.2
     transitivePeerDependencies:

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -5,6 +5,7 @@
     "declaration": true,
     "jsx": "react",
     "esModuleInterop": true,
-    "allowJs": true
+    "allowJs": true,
+    "strict": true
   }
 }


### PR DESCRIPTION
The issue from #115 is because the interpreter was using a `CharPos[]` as the type of [`WidgetRanges`](https://github.com/cognitive-engineering-lab/aquascope/blob/2ed6a15813600721219ddc504bd40f01a5bb9b36/frontend/packages/aquascope-editor/src/editor-utils/interpreter.tsx#L823-L825). 

I added the type annotation to prevent it from getting inferred as type `any`, and then the fix in the else branch is to compute the byte position from the `CharPos`.