### PR TITLE
duplicate icons

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -200,7 +200,7 @@ dependencies = [
 
 [[package]]
 name = "aquascope_workspace_utils"
-version = "0.3.4"
+version = "0.3.5"
 dependencies = [
  "anyhow",
  "serde",
@@ -1291,7 +1291,7 @@ dependencies = [
 
 [[package]]
 name = "mdbook-aquascope"
-version = "0.3.4"
+version = "0.3.5"
 dependencies = [
  "anyhow",
  "aquascope_workspace_utils",

--- a/crates/aquascope/src/analysis/mod.rs
+++ b/crates/aquascope/src/analysis/mod.rs
@@ -51,6 +51,16 @@ thread_local! {
 #[ts(export)]
 pub struct LoanKey(pub u32);
 
+/// Represents a point
+#[derive(
+  Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Serialize, TS,
+)]
+#[ts(export)]
+pub enum LoanRefined<T> {
+  RefineOnlyWrite { write_key: T },
+  RefineReadAndWrite { write_key: T },
+}
+
 #[derive(
   Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Serialize, TS,
 )]

--- a/crates/aquascope/src/analysis/permissions/context.rs
+++ b/crates/aquascope/src/analysis/permissions/context.rs
@@ -299,6 +299,7 @@ impl<'tcx> PermissionsCtxt<'tcx> {
       path_uninitialized: false,
       loan_read_refined: None,
       loan_write_refined: None,
+      loan_read_write_refined: None,
       loan_drop_refined: None,
     }
   }
@@ -362,6 +363,10 @@ impl<'tcx> PermissionsCtxt<'tcx> {
     let path_moved = pms.move_refined.get(point).unwrap_or(empty_hash_move);
     let loan_read_refined =
       pms.loan_read_refined.get(point).unwrap_or(empty_hash_loan);
+    let loan_read_write_refined = pms
+      .loan_read_write_refined
+      .get(point)
+      .unwrap_or(empty_hash_loan);
     let loan_write_refined =
       pms.loan_write_refined.get(point).unwrap_or(empty_hash_loan);
     let loan_drop_refined =
@@ -378,6 +383,8 @@ impl<'tcx> PermissionsCtxt<'tcx> {
       loan_read_refined.get(path).map(Into::<LoanKey>::into);
     let loan_write_refined: Option<LoanKey> =
       loan_write_refined.get(path).map(Into::<LoanKey>::into);
+    let loan_read_write_refined: Option<LoanKey> =
+      loan_read_write_refined.get(path).map(Into::<LoanKey>::into);
     let loan_drop_refined: Option<LoanKey> =
       loan_drop_refined.get(path).map(Into::<LoanKey>::into);
 
@@ -390,6 +397,7 @@ impl<'tcx> PermissionsCtxt<'tcx> {
       path_moved,
       loan_read_refined,
       loan_write_refined,
+      loan_read_write_refined,
       loan_drop_refined,
     }
   }
@@ -415,6 +423,7 @@ impl<'tcx> PermissionsCtxt<'tcx> {
           path_uninitialized: false,
           loan_read_refined: None,
           loan_write_refined: None,
+          loan_read_write_refined: None,
           loan_drop_refined: None,
         })
       })

--- a/crates/aquascope/src/analysis/permissions/context.rs
+++ b/crates/aquascope/src/analysis/permissions/context.rs
@@ -27,10 +27,13 @@ use rustc_span::Span;
 use rustc_utils::{BodyExt, PlaceExt, SpanExt, TyExt};
 use smallvec::{smallvec, SmallVec};
 
-use crate::analysis::permissions::{
-  flow::RegionFlows, AquascopeFacts, Loan, LoanKey, Move, MoveKey, Origin,
-  Output, Path, Permissions, PermissionsData, PermissionsDomain, Point,
-  Variable,
+use crate::analysis::{
+  permissions::{
+    flow::RegionFlows, AquascopeFacts, Loan, LoanKey, Move, MoveKey, Origin,
+    Output, Path, Permissions, PermissionsData, PermissionsDomain, Point,
+    Variable,
+  },
+  LoanRefined,
 };
 
 /// A path as defined in rustc.
@@ -299,7 +302,7 @@ impl<'tcx> PermissionsCtxt<'tcx> {
       path_uninitialized: false,
       loan_read_refined: None,
       loan_write_refined: None,
-      loan_read_write_refined: None,
+      loan_refined: None,
       loan_drop_refined: None,
     }
   }
@@ -363,10 +366,6 @@ impl<'tcx> PermissionsCtxt<'tcx> {
     let path_moved = pms.move_refined.get(point).unwrap_or(empty_hash_move);
     let loan_read_refined =
       pms.loan_read_refined.get(point).unwrap_or(empty_hash_loan);
-    let loan_read_write_refined = pms
-      .loan_read_write_refined
-      .get(point)
-      .unwrap_or(empty_hash_loan);
     let loan_write_refined =
       pms.loan_write_refined.get(point).unwrap_or(empty_hash_loan);
     let loan_drop_refined =
@@ -383,8 +382,22 @@ impl<'tcx> PermissionsCtxt<'tcx> {
       loan_read_refined.get(path).map(Into::<LoanKey>::into);
     let loan_write_refined: Option<LoanKey> =
       loan_write_refined.get(path).map(Into::<LoanKey>::into);
-    let loan_read_write_refined: Option<LoanKey> =
-      loan_read_write_refined.get(path).map(Into::<LoanKey>::into);
+
+    let loan_refined: Option<LoanRefined<LoanKey>> = match (
+      loan_read_refined,
+      loan_write_refined,
+    ) {
+      (Some(_read_key), Some(write_key)) => {
+        Some(LoanRefined::RefineReadAndWrite { write_key })
+      }
+      (None, Some(write_key)) => {
+        Some(LoanRefined::RefineOnlyWrite { write_key })
+      }
+      (Some(_read_key), None) => {
+        unreachable!("If read permissions are lost at a point, write permissions are also lost.")
+      }
+      (None, None) => None,
+    };
     let loan_drop_refined: Option<LoanKey> =
       loan_drop_refined.get(path).map(Into::<LoanKey>::into);
 
@@ -397,7 +410,7 @@ impl<'tcx> PermissionsCtxt<'tcx> {
       path_moved,
       loan_read_refined,
       loan_write_refined,
-      loan_read_write_refined,
+      loan_refined,
       loan_drop_refined,
     }
   }
@@ -423,7 +436,7 @@ impl<'tcx> PermissionsCtxt<'tcx> {
           path_uninitialized: false,
           loan_read_refined: None,
           loan_write_refined: None,
-          loan_read_write_refined: None,
+          loan_refined: None,
           loan_drop_refined: None,
         })
       })

--- a/crates/aquascope/src/analysis/permissions/mod.rs
+++ b/crates/aquascope/src/analysis/permissions/mod.rs
@@ -111,6 +111,10 @@ pub struct PermissionsData {
   pub loan_write_refined: Option<LoanKey>,
 
   #[serde(skip_serializing_if = "Option::is_none")]
+  /// Is a live loan removing `read` or `write` permissions?
+  pub loan_read_write_refined: Option<LoanKey>,
+
+  #[serde(skip_serializing_if = "Option::is_none")]
   /// Is a live loan removing `drop` permissions?
   pub loan_drop_refined: Option<LoanKey>,
 }

--- a/crates/aquascope/src/analysis/permissions/mod.rs
+++ b/crates/aquascope/src/analysis/permissions/mod.rs
@@ -20,7 +20,7 @@ use rustc_utils::source_map::range::CharRange;
 use serde::Serialize;
 use ts_rs::TS;
 
-use crate::analysis::{LoanKey, MoveKey};
+use crate::analysis::{LoanKey, LoanRefined, MoveKey};
 
 fluid_let!(pub static ENABLE_FLOW_PERMISSIONS: bool);
 pub const ENABLE_FLOW_DEFAULT: bool = false;
@@ -112,7 +112,7 @@ pub struct PermissionsData {
 
   #[serde(skip_serializing_if = "Option::is_none")]
   /// Is a live loan removing `read` or `write` permissions?
-  pub loan_read_write_refined: Option<LoanKey>,
+  pub loan_refined: Option<LoanRefined<LoanKey>>,
 
   #[serde(skip_serializing_if = "Option::is_none")]
   /// Is a live loan removing `drop` permissions?

--- a/crates/aquascope/src/analysis/permissions/output.rs
+++ b/crates/aquascope/src/analysis/permissions/output.rs
@@ -82,11 +82,6 @@ where
   ///
   pub(crate) loan_write_refined: HashMap<T::Point, HashMap<T::Path, T::Loan>>,
 
-  /// A [`Path`] whose write permissions are refined at [`Point`] due to an active [`Loan`].
-  ///
-  pub(crate) loan_read_write_refined:
-    HashMap<T::Point, HashMap<T::Path, T::Loan>>,
-
   /// A [`Path`] whose drop permissions are refined at [`Point`] due to an active [`Loan`].
   ///
   /// ```text
@@ -165,7 +160,6 @@ impl Default for Output<AquascopeFacts> {
       never_write: HashSet::default(),
       loan_read_refined: HashMap::default(),
       loan_write_refined: HashMap::default(),
-      loan_read_write_refined: HashMap::default(),
       loan_drop_refined: HashMap::default(),
       path_maybe_uninitialized_on_entry: HashMap::default(),
       move_refined: HashMap::default(),
@@ -434,9 +428,6 @@ pub fn derive_permission_facts(ctxt: &mut PermissionsCtxt) {
     |&loan, &path, &point| (path, loan, point),
   );
 
-  let loan_read_write_refined =
-    Relation::merge(loan_read_refined.clone(), loan_write_refined.clone());
-
   let loan_drop_refined: Relation<(Path, Loan, Point)> = Relation::from_join(
     &loan_conflicts_with,
     &loan_live_at,
@@ -482,10 +473,6 @@ pub fn derive_permission_facts(ctxt: &mut PermissionsCtxt) {
     };
   }
 
-  insert_facts!(
-    loan_read_write_refined,
-    ctxt.permissions_output.loan_read_write_refined
-  );
   insert_facts!(loan_read_refined, ctxt.permissions_output.loan_read_refined);
   insert_facts!(
     loan_write_refined,

--- a/crates/aquascope/src/analysis/permissions/output.rs
+++ b/crates/aquascope/src/analysis/permissions/output.rs
@@ -82,6 +82,11 @@ where
   ///
   pub(crate) loan_write_refined: HashMap<T::Point, HashMap<T::Path, T::Loan>>,
 
+  /// A [`Path`] whose write permissions are refined at [`Point`] due to an active [`Loan`].
+  ///
+  pub(crate) loan_read_write_refined:
+    HashMap<T::Point, HashMap<T::Path, T::Loan>>,
+
   /// A [`Path`] whose drop permissions are refined at [`Point`] due to an active [`Loan`].
   ///
   /// ```text
@@ -160,6 +165,7 @@ impl Default for Output<AquascopeFacts> {
       never_write: HashSet::default(),
       loan_read_refined: HashMap::default(),
       loan_write_refined: HashMap::default(),
+      loan_read_write_refined: HashMap::default(),
       loan_drop_refined: HashMap::default(),
       path_maybe_uninitialized_on_entry: HashMap::default(),
       move_refined: HashMap::default(),
@@ -428,6 +434,9 @@ pub fn derive_permission_facts(ctxt: &mut PermissionsCtxt) {
     |&loan, &path, &point| (path, loan, point),
   );
 
+  let loan_read_write_refined =
+    Relation::merge(loan_read_refined.clone(), loan_write_refined.clone());
+
   let loan_drop_refined: Relation<(Path, Loan, Point)> = Relation::from_join(
     &loan_conflicts_with,
     &loan_live_at,
@@ -473,6 +482,10 @@ pub fn derive_permission_facts(ctxt: &mut PermissionsCtxt) {
     };
   }
 
+  insert_facts!(
+    loan_read_write_refined,
+    ctxt.permissions_output.loan_read_write_refined
+  );
   insert_facts!(loan_read_refined, ctxt.permissions_output.loan_read_refined);
   insert_facts!(
     loan_write_refined,

--- a/crates/aquascope/src/analysis/stepper/mod.rs
+++ b/crates/aquascope/src/analysis/stepper/mod.rs
@@ -169,6 +169,7 @@ pub struct PermissionsDataDiff {
   pub path_uninitialized: ValueStep<bool>,
   pub loan_read_refined: ValueStep<LoanKey>,
   pub loan_write_refined: ValueStep<LoanKey>,
+  pub loan_read_write_refined: ValueStep<LoanKey>,
   pub loan_drop_refined: ValueStep<LoanKey>,
   pub permissions: PermissionsDiff,
 }
@@ -182,6 +183,11 @@ impl std::fmt::Debug for PermissionsDataDiff {
     writeln!(f, "    type_writeable:     {:?}", self.type_writeable)?;
     writeln!(f, "    path_moved:         {:?}", self.path_moved)?;
     writeln!(f, "    loan_write_refined: {:?}", self.loan_write_refined)?;
+    writeln!(
+      f,
+      "    loan_read_write_refined: {:?}",
+      self.loan_read_write_refined
+    )?;
     writeln!(f, "    loan_drop_refined:  {:?}", self.loan_drop_refined)?;
     Ok(())
   }
@@ -263,6 +269,9 @@ impl Difference for PermissionsData {
       type_writeable: self.type_writeable.diff(rhs.type_writeable),
       loan_read_refined: self.loan_read_refined.diff(rhs.loan_read_refined),
       loan_write_refined: self.loan_write_refined.diff(rhs.loan_write_refined),
+      loan_read_write_refined: self
+        .loan_read_write_refined
+        .diff(rhs.loan_read_write_refined),
       loan_drop_refined: self.loan_drop_refined.diff(rhs.loan_drop_refined),
       path_moved: self.path_moved.diff(rhs.path_moved),
       path_uninitialized: self.path_uninitialized.diff(rhs.path_uninitialized),

--- a/crates/aquascope/src/analysis/stepper/mod.rs
+++ b/crates/aquascope/src/analysis/stepper/mod.rs
@@ -17,6 +17,7 @@ use rustc_utils::source_map::range::CharRange;
 use serde::{Deserialize, Serialize};
 use ts_rs::TS;
 
+use super::LoanRefined;
 use crate::analysis::{
   permissions::{
     Permissions, PermissionsCtxt, PermissionsData, PermissionsDomain,
@@ -167,9 +168,9 @@ pub struct PermissionsDataDiff {
   pub type_writeable: ValueStep<bool>,
   pub path_moved: ValueStep<MoveKey>,
   pub path_uninitialized: ValueStep<bool>,
-  pub loan_read_refined: ValueStep<LoanKey>,
+  pub loan_read_refined: ValueStep<LoanKey>, // ValueStep<LoanRefined<LoanKey>> where LoanRefined is ReadOnly or ReadPlusWrite
   pub loan_write_refined: ValueStep<LoanKey>,
-  pub loan_read_write_refined: ValueStep<LoanKey>,
+  pub loan_refined: ValueStep<LoanRefined<LoanKey>>,
   pub loan_drop_refined: ValueStep<LoanKey>,
   pub permissions: PermissionsDiff,
 }
@@ -183,11 +184,7 @@ impl std::fmt::Debug for PermissionsDataDiff {
     writeln!(f, "    type_writeable:     {:?}", self.type_writeable)?;
     writeln!(f, "    path_moved:         {:?}", self.path_moved)?;
     writeln!(f, "    loan_write_refined: {:?}", self.loan_write_refined)?;
-    writeln!(
-      f,
-      "    loan_read_write_refined: {:?}",
-      self.loan_read_write_refined
-    )?;
+    writeln!(f, "    loan_refined: {:?}", self.loan_refined)?;
     writeln!(f, "    loan_drop_refined:  {:?}", self.loan_drop_refined)?;
     Ok(())
   }
@@ -269,9 +266,7 @@ impl Difference for PermissionsData {
       type_writeable: self.type_writeable.diff(rhs.type_writeable),
       loan_read_refined: self.loan_read_refined.diff(rhs.loan_read_refined),
       loan_write_refined: self.loan_write_refined.diff(rhs.loan_write_refined),
-      loan_read_write_refined: self
-        .loan_read_write_refined
-        .diff(rhs.loan_read_write_refined),
+      loan_refined: self.loan_refined.diff(rhs.loan_refined),
       loan_drop_refined: self.loan_drop_refined.diff(rhs.loan_drop_refined),
       path_moved: self.path_moved.diff(rhs.path_moved),
       path_uninitialized: self.path_uninitialized.diff(rhs.path_uninitialized),

--- a/crates/aquascope/tests/snapshots/boundaries__main@assignop_path_resolution.test.snap
+++ b/crates/aquascope/tests/snapshots/boundaries__main@assignop_path_resolution.test.snap
@@ -71,6 +71,9 @@ description: main@assignop_path_resolution.test
     is_live: true
     path_uninitialized: false
     loan_write_refined: 0
+    loan_refined:
+      RefineOnlyWrite:
+        write_key: 0
     loan_drop_refined: 0
 - location:
     line: 8

--- a/crates/aquascope/tests/snapshots/stepper__add_ref@if_2.test.snap
+++ b/crates/aquascope/tests/snapshots/stepper__add_ref@if_2.test.snap
@@ -22,6 +22,8 @@ description: add_ref@if_2.test
           type: None
         loan_write_refined:
           type: None
+        loan_refined:
+          type: None
         loan_drop_refined:
           type: None
         permissions:
@@ -52,6 +54,8 @@ description: add_ref@if_2.test
         loan_read_refined:
           type: None
         loan_write_refined:
+          type: None
+        loan_refined:
           type: None
         loan_drop_refined:
           type: None
@@ -84,6 +88,8 @@ description: add_ref@if_2.test
           type: None
         loan_write_refined:
           type: None
+        loan_refined:
+          type: None
         loan_drop_refined:
           type: None
         permissions:
@@ -114,6 +120,8 @@ description: add_ref@if_2.test
         loan_read_refined:
           type: None
         loan_write_refined:
+          type: None
+        loan_refined:
           type: None
         loan_drop_refined:
           type: None
@@ -146,6 +154,8 @@ description: add_ref@if_2.test
         loan_read_refined:
           type: None
         loan_write_refined:
+          type: None
+        loan_refined:
           type: None
         loan_drop_refined:
           type: None
@@ -181,6 +191,11 @@ description: add_ref@if_2.test
         loan_write_refined:
           type: High
           value: 0
+        loan_refined:
+          type: High
+          value:
+            RefineReadAndWrite:
+              write_key: 0
         loan_drop_refined:
           type: High
           value: 0
@@ -213,6 +228,11 @@ description: add_ref@if_2.test
         loan_write_refined:
           type: High
           value: 0
+        loan_refined:
+          type: High
+          value:
+            RefineReadAndWrite:
+              write_key: 0
         loan_drop_refined:
           type: High
           value: 0
@@ -246,6 +266,11 @@ description: add_ref@if_2.test
         loan_write_refined:
           type: High
           value: 11
+        loan_refined:
+          type: High
+          value:
+            RefineReadAndWrite:
+              write_key: 11
         loan_drop_refined:
           type: High
           value: 11
@@ -276,6 +301,8 @@ description: add_ref@if_2.test
           type: None
         loan_write_refined:
           type: None
+        loan_refined:
+          type: None
         loan_drop_refined:
           type: None
         permissions:
@@ -305,6 +332,8 @@ description: add_ref@if_2.test
         loan_read_refined:
           type: None
         loan_write_refined:
+          type: None
+        loan_refined:
           type: None
         loan_drop_refined:
           type: None
@@ -337,6 +366,8 @@ description: add_ref@if_2.test
           type: None
         loan_write_refined:
           type: None
+        loan_refined:
+          type: None
         loan_drop_refined:
           type: None
         permissions:
@@ -366,6 +397,8 @@ description: add_ref@if_2.test
         loan_read_refined:
           type: None
         loan_write_refined:
+          type: None
+        loan_refined:
           type: None
         loan_drop_refined:
           type: None
@@ -398,6 +431,8 @@ description: add_ref@if_2.test
           type: None
         loan_write_refined:
           type: None
+        loan_refined:
+          type: None
         loan_drop_refined:
           type: None
         permissions:
@@ -426,6 +461,8 @@ description: add_ref@if_2.test
         loan_read_refined:
           type: None
         loan_write_refined:
+          type: None
+        loan_refined:
           type: None
         loan_drop_refined:
           type: None
@@ -456,6 +493,8 @@ description: add_ref@if_2.test
           type: None
         loan_write_refined:
           type: None
+        loan_refined:
+          type: None
         loan_drop_refined:
           type: None
         permissions:
@@ -483,6 +522,8 @@ description: add_ref@if_2.test
         loan_read_refined:
           type: None
         loan_write_refined:
+          type: None
+        loan_refined:
           type: None
         loan_drop_refined:
           type: None
@@ -513,6 +554,8 @@ description: add_ref@if_2.test
           type: None
         loan_write_refined:
           type: None
+        loan_refined:
+          type: None
         loan_drop_refined:
           type: None
         permissions:
@@ -541,6 +584,8 @@ description: add_ref@if_2.test
         loan_read_refined:
           type: Low
         loan_write_refined:
+          type: Low
+        loan_refined:
           type: Low
         loan_drop_refined:
           type: Low
@@ -572,6 +617,8 @@ description: add_ref@if_2.test
           type: None
         loan_write_refined:
           type: None
+        loan_refined:
+          type: None
         loan_drop_refined:
           type: None
         permissions:
@@ -600,6 +647,8 @@ description: add_ref@if_2.test
         loan_read_refined:
           type: Low
         loan_write_refined:
+          type: Low
+        loan_refined:
           type: Low
         loan_drop_refined:
           type: Low
@@ -632,6 +681,8 @@ description: add_ref@if_2.test
           type: Low
         loan_write_refined:
           type: Low
+        loan_refined:
+          type: Low
         loan_drop_refined:
           type: Low
         permissions:
@@ -663,6 +714,8 @@ description: add_ref@if_2.test
           type: None
         loan_write_refined:
           type: None
+        loan_refined:
+          type: None
         loan_drop_refined:
           type: None
         permissions:
@@ -690,6 +743,8 @@ description: add_ref@if_2.test
         loan_read_refined:
           type: None
         loan_write_refined:
+          type: None
+        loan_refined:
           type: None
         loan_drop_refined:
           type: None
@@ -719,6 +774,8 @@ description: add_ref@if_2.test
           type: None
         loan_write_refined:
           type: None
+        loan_refined:
+          type: None
         loan_drop_refined:
           type: None
         permissions:
@@ -729,4 +786,3 @@ description: add_ref@if_2.test
             value: false
           drop:
             type: Low
-

--- a/crates/aquascope/tests/snapshots/stepper__ascii_capitalize@if_3.test.snap
+++ b/crates/aquascope/tests/snapshots/stepper__ascii_capitalize@if_3.test.snap
@@ -22,6 +22,8 @@ description: ascii_capitalize@if_3.test
           type: None
         loan_write_refined:
           type: None
+        loan_refined:
+          type: None
         loan_drop_refined:
           type: None
         permissions:
@@ -52,6 +54,8 @@ description: ascii_capitalize@if_3.test
         loan_read_refined:
           type: None
         loan_write_refined:
+          type: None
+        loan_refined:
           type: None
         loan_drop_refined:
           type: None
@@ -85,6 +89,8 @@ description: ascii_capitalize@if_3.test
           type: None
         loan_write_refined:
           type: None
+        loan_refined:
+          type: None
         loan_drop_refined:
           type: None
         permissions:
@@ -117,6 +123,11 @@ description: ascii_capitalize@if_3.test
         loan_write_refined:
           type: High
           value: 0
+        loan_refined:
+          type: High
+          value:
+            RefineOnlyWrite:
+              write_key: 0
         loan_drop_refined:
           type: High
           value: 0
@@ -147,6 +158,8 @@ description: ascii_capitalize@if_3.test
         loan_read_refined:
           type: None
         loan_write_refined:
+          type: None
+        loan_refined:
           type: None
         loan_drop_refined:
           type: None
@@ -180,6 +193,11 @@ description: ascii_capitalize@if_3.test
         loan_write_refined:
           type: High
           value: 0
+        loan_refined:
+          type: High
+          value:
+            RefineOnlyWrite:
+              write_key: 0
         loan_drop_refined:
           type: High
           value: 0
@@ -211,6 +229,8 @@ description: ascii_capitalize@if_3.test
           type: None
         loan_write_refined:
           type: None
+        loan_refined:
+          type: None
         loan_drop_refined:
           type: None
         permissions:
@@ -240,6 +260,8 @@ description: ascii_capitalize@if_3.test
         loan_read_refined:
           type: None
         loan_write_refined:
+          type: Low
+        loan_refined:
           type: Low
         loan_drop_refined:
           type: Low
@@ -271,6 +293,8 @@ description: ascii_capitalize@if_3.test
           type: None
         loan_write_refined:
           type: None
+        loan_refined:
+          type: None
         loan_drop_refined:
           type: None
         permissions:
@@ -298,6 +322,8 @@ description: ascii_capitalize@if_3.test
         loan_read_refined:
           type: None
         loan_write_refined:
+          type: None
+        loan_refined:
           type: None
         loan_drop_refined:
           type: None
@@ -329,6 +355,8 @@ description: ascii_capitalize@if_3.test
         loan_read_refined:
           type: None
         loan_write_refined:
+          type: Low
+        loan_refined:
           type: Low
         loan_drop_refined:
           type: Low
@@ -361,6 +389,8 @@ description: ascii_capitalize@if_3.test
           type: None
         loan_write_refined:
           type: None
+        loan_refined:
+          type: None
         loan_drop_refined:
           type: None
         permissions:
@@ -388,6 +418,8 @@ description: ascii_capitalize@if_3.test
         loan_read_refined:
           type: None
         loan_write_refined:
+          type: None
+        loan_refined:
           type: None
         loan_drop_refined:
           type: None
@@ -417,6 +449,8 @@ description: ascii_capitalize@if_3.test
           type: None
         loan_write_refined:
           type: None
+        loan_refined:
+          type: None
         loan_drop_refined:
           type: None
         permissions:
@@ -445,6 +479,8 @@ description: ascii_capitalize@if_3.test
         loan_read_refined:
           type: None
         loan_write_refined:
+          type: None
+        loan_refined:
           type: None
         loan_drop_refined:
           type: None
@@ -476,6 +512,8 @@ description: ascii_capitalize@if_3.test
           type: None
         loan_write_refined:
           type: Low
+        loan_refined:
+          type: Low
         loan_drop_refined:
           type: Low
         permissions:
@@ -506,6 +544,8 @@ description: ascii_capitalize@if_3.test
           type: None
         loan_write_refined:
           type: None
+        loan_refined:
+          type: None
         loan_drop_refined:
           type: None
         permissions:
@@ -534,6 +574,8 @@ description: ascii_capitalize@if_3.test
         loan_read_refined:
           type: None
         loan_write_refined:
+          type: Low
+        loan_refined:
           type: Low
         loan_drop_refined:
           type: Low
@@ -566,6 +608,8 @@ description: ascii_capitalize@if_3.test
           type: None
         loan_write_refined:
           type: None
+        loan_refined:
+          type: None
         loan_drop_refined:
           type: None
         permissions:
@@ -594,6 +638,8 @@ description: ascii_capitalize@if_3.test
           type: None
         loan_write_refined:
           type: None
+        loan_refined:
+          type: None
         loan_drop_refined:
           type: None
         permissions:
@@ -604,4 +650,3 @@ description: ascii_capitalize@if_3.test
             value: false
           drop:
             type: Low
-

--- a/crates/aquascope/tests/snapshots/stepper__foo@if_4.test.snap
+++ b/crates/aquascope/tests/snapshots/stepper__foo@if_4.test.snap
@@ -22,6 +22,8 @@ description: foo@if_4.test
           type: None
         loan_write_refined:
           type: None
+        loan_refined:
+          type: None
         loan_drop_refined:
           type: None
         permissions:
@@ -54,6 +56,8 @@ description: foo@if_4.test
           type: None
         loan_write_refined:
           type: None
+        loan_refined:
+          type: None
         loan_drop_refined:
           type: None
         permissions:
@@ -84,6 +88,8 @@ description: foo@if_4.test
         loan_read_refined:
           type: None
         loan_write_refined:
+          type: None
+        loan_refined:
           type: None
         loan_drop_refined:
           type: None
@@ -118,6 +124,11 @@ description: foo@if_4.test
         loan_write_refined:
           type: High
           value: 0
+        loan_refined:
+          type: High
+          value:
+            RefineReadAndWrite:
+              write_key: 0
         loan_drop_refined:
           type: High
           value: 0
@@ -146,6 +157,8 @@ description: foo@if_4.test
         loan_read_refined:
           type: None
         loan_write_refined:
+          type: None
+        loan_refined:
           type: None
         loan_drop_refined:
           type: None
@@ -178,6 +191,8 @@ description: foo@if_4.test
           type: None
         loan_write_refined:
           type: None
+        loan_refined:
+          type: None
         loan_drop_refined:
           type: None
         permissions:
@@ -209,6 +224,8 @@ description: foo@if_4.test
           type: None
         loan_write_refined:
           type: None
+        loan_refined:
+          type: None
         loan_drop_refined:
           type: None
         permissions:
@@ -236,6 +253,8 @@ description: foo@if_4.test
         loan_read_refined:
           type: None
         loan_write_refined:
+          type: None
+        loan_refined:
           type: None
         loan_drop_refined:
           type: None
@@ -266,6 +285,8 @@ description: foo@if_4.test
           type: None
         loan_write_refined:
           type: None
+        loan_refined:
+          type: None
         loan_drop_refined:
           type: None
         permissions:
@@ -293,6 +314,8 @@ description: foo@if_4.test
         loan_read_refined:
           type: None
         loan_write_refined:
+          type: None
+        loan_refined:
           type: None
         loan_drop_refined:
           type: None
@@ -323,6 +346,8 @@ description: foo@if_4.test
           type: None
         loan_write_refined:
           type: None
+        loan_refined:
+          type: None
         loan_drop_refined:
           type: None
         permissions:
@@ -350,6 +375,8 @@ description: foo@if_4.test
         loan_read_refined:
           type: None
         loan_write_refined:
+          type: None
+        loan_refined:
           type: None
         loan_drop_refined:
           type: None
@@ -379,6 +406,8 @@ description: foo@if_4.test
         loan_read_refined:
           type: Low
         loan_write_refined:
+          type: Low
+        loan_refined:
           type: Low
         loan_drop_refined:
           type: Low
@@ -411,6 +440,8 @@ description: foo@if_4.test
           type: None
         loan_write_refined:
           type: None
+        loan_refined:
+          type: None
         loan_drop_refined:
           type: None
         permissions:
@@ -420,4 +451,3 @@ description: foo@if_4.test
             type: Low
           drop:
             type: Low
-

--- a/crates/aquascope/tests/snapshots/stepper__foo@interior_move.test.snap
+++ b/crates/aquascope/tests/snapshots/stepper__foo@interior_move.test.snap
@@ -22,6 +22,8 @@ description: foo@interior_move.test
           type: None
         loan_write_refined:
           type: None
+        loan_refined:
+          type: None
         loan_drop_refined:
           type: None
         permissions:
@@ -52,6 +54,8 @@ description: foo@interior_move.test
         loan_read_refined:
           type: None
         loan_write_refined:
+          type: None
+        loan_refined:
           type: None
         loan_drop_refined:
           type: None
@@ -84,6 +88,8 @@ description: foo@interior_move.test
           type: None
         loan_write_refined:
           type: None
+        loan_refined:
+          type: None
         loan_drop_refined:
           type: None
         permissions:
@@ -114,6 +120,8 @@ description: foo@interior_move.test
         loan_read_refined:
           type: None
         loan_write_refined:
+          type: None
+        loan_refined:
           type: None
         loan_drop_refined:
           type: None
@@ -147,6 +155,8 @@ description: foo@interior_move.test
           type: None
         loan_write_refined:
           type: None
+        loan_refined:
+          type: None
         loan_drop_refined:
           type: None
         permissions:
@@ -175,6 +185,8 @@ description: foo@interior_move.test
         loan_read_refined:
           type: None
         loan_write_refined:
+          type: None
+        loan_refined:
           type: None
         loan_drop_refined:
           type: None
@@ -205,6 +217,8 @@ description: foo@interior_move.test
           type: None
         loan_write_refined:
           type: None
+        loan_refined:
+          type: None
         loan_drop_refined:
           type: None
         permissions:
@@ -233,6 +247,8 @@ description: foo@interior_move.test
         loan_read_refined:
           type: None
         loan_write_refined:
+          type: None
+        loan_refined:
           type: None
         loan_drop_refined:
           type: None
@@ -263,6 +279,8 @@ description: foo@interior_move.test
         loan_read_refined:
           type: None
         loan_write_refined:
+          type: None
+        loan_refined:
           type: None
         loan_drop_refined:
           type: None
@@ -296,6 +314,8 @@ description: foo@interior_move.test
           type: None
         loan_write_refined:
           type: None
+        loan_refined:
+          type: None
         loan_drop_refined:
           type: None
         permissions:
@@ -323,6 +343,8 @@ description: foo@interior_move.test
         loan_read_refined:
           type: None
         loan_write_refined:
+          type: None
+        loan_refined:
           type: None
         loan_drop_refined:
           type: None
@@ -352,6 +374,8 @@ description: foo@interior_move.test
           type: None
         loan_write_refined:
           type: None
+        loan_refined:
+          type: None
         loan_drop_refined:
           type: None
         permissions:
@@ -361,4 +385,3 @@ description: foo@interior_move.test
             type: Low
           drop:
             type: Low
-

--- a/crates/aquascope/tests/snapshots/stepper__foo@interior_move_1.test.snap
+++ b/crates/aquascope/tests/snapshots/stepper__foo@interior_move_1.test.snap
@@ -22,6 +22,8 @@ description: foo@interior_move_1.test
           type: None
         loan_write_refined:
           type: None
+        loan_refined:
+          type: None
         loan_drop_refined:
           type: None
         permissions:
@@ -53,6 +55,8 @@ description: foo@interior_move_1.test
           type: None
         loan_write_refined:
           type: None
+        loan_refined:
+          type: None
         loan_drop_refined:
           type: None
         permissions:
@@ -83,6 +87,8 @@ description: foo@interior_move_1.test
         loan_read_refined:
           type: None
         loan_write_refined:
+          type: None
+        loan_refined:
           type: None
         loan_drop_refined:
           type: None
@@ -115,6 +121,8 @@ description: foo@interior_move_1.test
           type: None
         loan_write_refined:
           type: None
+        loan_refined:
+          type: None
         loan_drop_refined:
           type: None
         permissions:
@@ -146,6 +154,8 @@ description: foo@interior_move_1.test
           type: None
         loan_write_refined:
           type: None
+        loan_refined:
+          type: None
         loan_drop_refined:
           type: None
         permissions:
@@ -174,6 +184,8 @@ description: foo@interior_move_1.test
           type: None
         loan_write_refined:
           type: None
+        loan_refined:
+          type: None
         loan_drop_refined:
           type: None
         permissions:
@@ -200,6 +212,8 @@ description: foo@interior_move_1.test
         loan_read_refined:
           type: None
         loan_write_refined:
+          type: None
+        loan_refined:
           type: None
         loan_drop_refined:
           type: None
@@ -230,6 +244,8 @@ description: foo@interior_move_1.test
           type: None
         loan_write_refined:
           type: None
+        loan_refined:
+          type: None
         loan_drop_refined:
           type: None
         permissions:
@@ -258,6 +274,8 @@ description: foo@interior_move_1.test
         loan_read_refined:
           type: None
         loan_write_refined:
+          type: None
+        loan_refined:
           type: None
         loan_drop_refined:
           type: None
@@ -289,6 +307,8 @@ description: foo@interior_move_1.test
           type: None
         loan_write_refined:
           type: None
+        loan_refined:
+          type: None
         loan_drop_refined:
           type: None
         permissions:
@@ -319,6 +339,8 @@ description: foo@interior_move_1.test
         loan_read_refined:
           type: None
         loan_write_refined:
+          type: None
+        loan_refined:
           type: None
         loan_drop_refined:
           type: None
@@ -352,6 +374,8 @@ description: foo@interior_move_1.test
           type: None
         loan_write_refined:
           type: None
+        loan_refined:
+          type: None
         loan_drop_refined:
           type: None
         permissions:
@@ -379,6 +403,8 @@ description: foo@interior_move_1.test
         loan_read_refined:
           type: None
         loan_write_refined:
+          type: None
+        loan_refined:
           type: None
         loan_drop_refined:
           type: None
@@ -408,6 +434,8 @@ description: foo@interior_move_1.test
           type: None
         loan_write_refined:
           type: None
+        loan_refined:
+          type: None
         loan_drop_refined:
           type: None
         permissions:
@@ -417,4 +445,3 @@ description: foo@interior_move_1.test
             type: Low
           drop:
             type: Low
-

--- a/crates/aquascope/tests/snapshots/stepper__foo@match_0.test.snap
+++ b/crates/aquascope/tests/snapshots/stepper__foo@match_0.test.snap
@@ -22,6 +22,8 @@ description: foo@match_0.test
           type: None
         loan_write_refined:
           type: None
+        loan_refined:
+          type: None
         loan_drop_refined:
           type: None
         permissions:
@@ -54,6 +56,8 @@ description: foo@match_0.test
           type: None
         loan_write_refined:
           type: None
+        loan_refined:
+          type: None
         loan_drop_refined:
           type: None
         permissions:
@@ -84,6 +88,8 @@ description: foo@match_0.test
         loan_read_refined:
           type: None
         loan_write_refined:
+          type: None
+        loan_refined:
           type: None
         loan_drop_refined:
           type: None
@@ -118,6 +124,11 @@ description: foo@match_0.test
         loan_write_refined:
           type: High
           value: 0
+        loan_refined:
+          type: High
+          value:
+            RefineReadAndWrite:
+              write_key: 0
         loan_drop_refined:
           type: High
           value: 0
@@ -146,6 +157,8 @@ description: foo@match_0.test
         loan_read_refined:
           type: None
         loan_write_refined:
+          type: None
+        loan_refined:
           type: None
         loan_drop_refined:
           type: None
@@ -178,6 +191,8 @@ description: foo@match_0.test
           type: None
         loan_write_refined:
           type: None
+        loan_refined:
+          type: None
         loan_drop_refined:
           type: None
         permissions:
@@ -209,6 +224,8 @@ description: foo@match_0.test
           type: None
         loan_write_refined:
           type: None
+        loan_refined:
+          type: None
         loan_drop_refined:
           type: None
         permissions:
@@ -236,6 +253,8 @@ description: foo@match_0.test
         loan_read_refined:
           type: None
         loan_write_refined:
+          type: None
+        loan_refined:
           type: None
         loan_drop_refined:
           type: None
@@ -266,6 +285,8 @@ description: foo@match_0.test
           type: None
         loan_write_refined:
           type: None
+        loan_refined:
+          type: None
         loan_drop_refined:
           type: None
         permissions:
@@ -293,6 +314,8 @@ description: foo@match_0.test
         loan_read_refined:
           type: None
         loan_write_refined:
+          type: None
+        loan_refined:
           type: None
         loan_drop_refined:
           type: None
@@ -323,6 +346,8 @@ description: foo@match_0.test
           type: None
         loan_write_refined:
           type: None
+        loan_refined:
+          type: None
         loan_drop_refined:
           type: None
         permissions:
@@ -350,6 +375,8 @@ description: foo@match_0.test
         loan_read_refined:
           type: None
         loan_write_refined:
+          type: None
+        loan_refined:
           type: None
         loan_drop_refined:
           type: None
@@ -379,6 +406,8 @@ description: foo@match_0.test
         loan_read_refined:
           type: Low
         loan_write_refined:
+          type: Low
+        loan_refined:
           type: Low
         loan_drop_refined:
           type: Low
@@ -411,6 +440,8 @@ description: foo@match_0.test
           type: None
         loan_write_refined:
           type: None
+        loan_refined:
+          type: None
         loan_drop_refined:
           type: None
         permissions:
@@ -420,4 +451,3 @@ description: foo@match_0.test
             type: Low
           drop:
             type: Low
-

--- a/crates/aquascope/tests/snapshots/stepper__main@for_loop_0.test.snap
+++ b/crates/aquascope/tests/snapshots/stepper__main@for_loop_0.test.snap
@@ -22,6 +22,8 @@ description: main@for_loop_0.test
           type: None
         loan_write_refined:
           type: None
+        loan_refined:
+          type: None
         loan_drop_refined:
           type: None
         permissions:
@@ -54,6 +56,8 @@ description: main@for_loop_0.test
           type: None
         loan_write_refined:
           type: None
+        loan_refined:
+          type: None
         loan_drop_refined:
           type: None
         permissions:
@@ -83,6 +87,8 @@ description: main@for_loop_0.test
         loan_read_refined:
           type: None
         loan_write_refined:
+          type: None
+        loan_refined:
           type: None
         loan_drop_refined:
           type: None
@@ -117,6 +123,11 @@ description: main@for_loop_0.test
         loan_write_refined:
           type: High
           value: 0
+        loan_refined:
+          type: High
+          value:
+            RefineReadAndWrite:
+              write_key: 0
         loan_drop_refined:
           type: High
           value: 0
@@ -145,6 +156,8 @@ description: main@for_loop_0.test
         loan_read_refined:
           type: None
         loan_write_refined:
+          type: None
+        loan_refined:
           type: None
         loan_drop_refined:
           type: None
@@ -179,6 +192,11 @@ description: main@for_loop_0.test
         loan_write_refined:
           type: High
           value: 1
+        loan_refined:
+          type: High
+          value:
+            RefineOnlyWrite:
+              write_key: 1
         loan_drop_refined:
           type: High
           value: 1
@@ -209,6 +227,8 @@ description: main@for_loop_0.test
           type: None
         loan_write_refined:
           type: None
+        loan_refined:
+          type: None
         loan_drop_refined:
           type: None
         permissions:
@@ -236,6 +256,8 @@ description: main@for_loop_0.test
         loan_read_refined:
           type: None
         loan_write_refined:
+          type: None
+        loan_refined:
           type: None
         loan_drop_refined:
           type: None
@@ -265,6 +287,8 @@ description: main@for_loop_0.test
         loan_read_refined:
           type: Low
         loan_write_refined:
+          type: Low
+        loan_refined:
           type: Low
         loan_drop_refined:
           type: Low
@@ -297,6 +321,8 @@ description: main@for_loop_0.test
           type: None
         loan_write_refined:
           type: Low
+        loan_refined:
+          type: Low
         loan_drop_refined:
           type: Low
         permissions:
@@ -328,6 +354,8 @@ description: main@for_loop_0.test
           type: None
         loan_write_refined:
           type: None
+        loan_refined:
+          type: None
         loan_drop_refined:
           type: None
         permissions:
@@ -356,6 +384,8 @@ description: main@for_loop_0.test
           type: None
         loan_write_refined:
           type: None
+        loan_refined:
+          type: None
         loan_drop_refined:
           type: None
         permissions:
@@ -365,4 +395,3 @@ description: main@for_loop_0.test
             type: Low
           drop:
             type: Low
-

--- a/crates/aquascope/tests/snapshots/stepper__main@if_0.test.snap
+++ b/crates/aquascope/tests/snapshots/stepper__main@if_0.test.snap
@@ -22,6 +22,8 @@ description: main@if_0.test
           type: None
         loan_write_refined:
           type: None
+        loan_refined:
+          type: None
         loan_drop_refined:
           type: None
         permissions:
@@ -52,6 +54,8 @@ description: main@if_0.test
         loan_read_refined:
           type: None
         loan_write_refined:
+          type: None
+        loan_refined:
           type: None
         loan_drop_refined:
           type: None
@@ -87,6 +91,11 @@ description: main@if_0.test
         loan_write_refined:
           type: High
           value: 0
+        loan_refined:
+          type: High
+          value:
+            RefineReadAndWrite:
+              write_key: 0
         loan_drop_refined:
           type: High
           value: 0
@@ -119,6 +128,11 @@ description: main@if_0.test
         loan_write_refined:
           type: High
           value: 4
+        loan_refined:
+          type: High
+          value:
+            RefineReadAndWrite:
+              write_key: 4
         loan_drop_refined:
           type: High
           value: 4
@@ -149,6 +163,8 @@ description: main@if_0.test
           type: None
         loan_write_refined:
           type: None
+        loan_refined:
+          type: None
         loan_drop_refined:
           type: None
         permissions:
@@ -178,6 +194,8 @@ description: main@if_0.test
         loan_read_refined:
           type: None
         loan_write_refined:
+          type: None
+        loan_refined:
           type: None
         loan_drop_refined:
           type: None
@@ -210,6 +228,8 @@ description: main@if_0.test
           type: None
         loan_write_refined:
           type: None
+        loan_refined:
+          type: None
         loan_drop_refined:
           type: None
         permissions:
@@ -237,6 +257,8 @@ description: main@if_0.test
         loan_read_refined:
           type: None
         loan_write_refined:
+          type: None
+        loan_refined:
           type: None
         loan_drop_refined:
           type: None
@@ -266,6 +288,8 @@ description: main@if_0.test
         loan_read_refined:
           type: Low
         loan_write_refined:
+          type: Low
+        loan_refined:
           type: Low
         loan_drop_refined:
           type: Low
@@ -298,6 +322,8 @@ description: main@if_0.test
           type: Low
         loan_write_refined:
           type: Low
+        loan_refined:
+          type: Low
         loan_drop_refined:
           type: Low
         permissions:
@@ -329,6 +355,8 @@ description: main@if_0.test
           type: None
         loan_write_refined:
           type: None
+        loan_refined:
+          type: None
         loan_drop_refined:
           type: None
         permissions:
@@ -357,6 +385,8 @@ description: main@if_0.test
           type: None
         loan_write_refined:
           type: None
+        loan_refined:
+          type: None
         loan_drop_refined:
           type: None
         permissions:
@@ -366,4 +396,3 @@ description: main@if_0.test
             type: Low
           drop:
             type: Low
-

--- a/crates/aquascope/tests/snapshots/stepper__main@if_1.test.snap
+++ b/crates/aquascope/tests/snapshots/stepper__main@if_1.test.snap
@@ -22,6 +22,8 @@ description: main@if_1.test
           type: None
         loan_write_refined:
           type: None
+        loan_refined:
+          type: None
         loan_drop_refined:
           type: None
         permissions:
@@ -52,6 +54,8 @@ description: main@if_1.test
         loan_read_refined:
           type: None
         loan_write_refined:
+          type: None
+        loan_refined:
           type: None
         loan_drop_refined:
           type: None
@@ -85,6 +89,8 @@ description: main@if_1.test
           type: None
         loan_write_refined:
           type: None
+        loan_refined:
+          type: None
         loan_drop_refined:
           type: None
         permissions:
@@ -114,6 +120,8 @@ description: main@if_1.test
         loan_read_refined:
           type: None
         loan_write_refined:
+          type: None
+        loan_refined:
           type: None
         loan_drop_refined:
           type: None
@@ -148,6 +156,11 @@ description: main@if_1.test
         loan_write_refined:
           type: High
           value: 0
+        loan_refined:
+          type: High
+          value:
+            RefineReadAndWrite:
+              write_key: 0
         loan_drop_refined:
           type: High
           value: 0
@@ -178,6 +191,8 @@ description: main@if_1.test
           type: None
         loan_write_refined:
           type: None
+        loan_refined:
+          type: None
         loan_drop_refined:
           type: None
         permissions:
@@ -207,6 +222,8 @@ description: main@if_1.test
         loan_read_refined:
           type: None
         loan_write_refined:
+          type: None
+        loan_refined:
           type: None
         loan_drop_refined:
           type: None
@@ -241,6 +258,11 @@ description: main@if_1.test
         loan_write_refined:
           type: High
           value: 4
+        loan_refined:
+          type: High
+          value:
+            RefineReadAndWrite:
+              write_key: 4
         loan_drop_refined:
           type: High
           value: 4
@@ -270,6 +292,8 @@ description: main@if_1.test
           type: None
         loan_write_refined:
           type: None
+        loan_refined:
+          type: None
         loan_drop_refined:
           type: None
         permissions:
@@ -297,6 +321,8 @@ description: main@if_1.test
         loan_read_refined:
           type: None
         loan_write_refined:
+          type: None
+        loan_refined:
           type: None
         loan_drop_refined:
           type: None
@@ -327,6 +353,8 @@ description: main@if_1.test
           type: Low
         loan_write_refined:
           type: Low
+        loan_refined:
+          type: Low
         loan_drop_refined:
           type: Low
         permissions:
@@ -357,6 +385,8 @@ description: main@if_1.test
         loan_read_refined:
           type: Low
         loan_write_refined:
+          type: Low
+        loan_refined:
           type: Low
         loan_drop_refined:
           type: Low
@@ -389,6 +419,8 @@ description: main@if_1.test
           type: None
         loan_write_refined:
           type: None
+        loan_refined:
+          type: None
         loan_drop_refined:
           type: None
         permissions:
@@ -417,6 +449,8 @@ description: main@if_1.test
           type: None
         loan_write_refined:
           type: None
+        loan_refined:
+          type: None
         loan_drop_refined:
           type: None
         permissions:
@@ -426,4 +460,3 @@ description: main@if_1.test
             type: Low
           drop:
             type: Low
-

--- a/crates/aquascope/tests/snapshots/stepper__main@linear_0.test.snap
+++ b/crates/aquascope/tests/snapshots/stepper__main@linear_0.test.snap
@@ -22,6 +22,8 @@ description: main@linear_0.test
           type: None
         loan_write_refined:
           type: None
+        loan_refined:
+          type: None
         loan_drop_refined:
           type: None
         permissions:
@@ -52,6 +54,8 @@ description: main@linear_0.test
         loan_read_refined:
           type: None
         loan_write_refined:
+          type: None
+        loan_refined:
           type: None
         loan_drop_refined:
           type: None
@@ -85,6 +89,8 @@ description: main@linear_0.test
           type: None
         loan_write_refined:
           type: None
+        loan_refined:
+          type: None
         loan_drop_refined:
           type: None
         permissions:
@@ -117,6 +123,11 @@ description: main@linear_0.test
         loan_write_refined:
           type: High
           value: 0
+        loan_refined:
+          type: High
+          value:
+            RefineReadAndWrite:
+              write_key: 0
         loan_drop_refined:
           type: High
           value: 0
@@ -144,6 +155,8 @@ description: main@linear_0.test
         loan_read_refined:
           type: None
         loan_write_refined:
+          type: None
+        loan_refined:
           type: None
         loan_drop_refined:
           type: None
@@ -176,6 +189,8 @@ description: main@linear_0.test
           type: None
         loan_write_refined:
           type: None
+        loan_refined:
+          type: None
         loan_drop_refined:
           type: None
         permissions:
@@ -203,6 +218,8 @@ description: main@linear_0.test
         loan_read_refined:
           type: None
         loan_write_refined:
+          type: None
+        loan_refined:
           type: None
         loan_drop_refined:
           type: None
@@ -232,6 +249,8 @@ description: main@linear_0.test
           type: None
         loan_write_refined:
           type: None
+        loan_refined:
+          type: None
         loan_drop_refined:
           type: None
         permissions:
@@ -242,4 +261,3 @@ description: main@linear_0.test
             value: false
           drop:
             type: Low
-

--- a/crates/aquascope/tests/snapshots/stepper__main@while_loop_0.test.snap
+++ b/crates/aquascope/tests/snapshots/stepper__main@while_loop_0.test.snap
@@ -22,6 +22,8 @@ description: main@while_loop_0.test
           type: None
         loan_write_refined:
           type: None
+        loan_refined:
+          type: None
         loan_drop_refined:
           type: None
         permissions:
@@ -54,6 +56,8 @@ description: main@while_loop_0.test
           type: None
         loan_write_refined:
           type: None
+        loan_refined:
+          type: None
         loan_drop_refined:
           type: None
         permissions:
@@ -83,6 +87,8 @@ description: main@while_loop_0.test
         loan_read_refined:
           type: None
         loan_write_refined:
+          type: None
+        loan_refined:
           type: None
         loan_drop_refined:
           type: None
@@ -117,6 +123,11 @@ description: main@while_loop_0.test
         loan_write_refined:
           type: High
           value: 0
+        loan_refined:
+          type: High
+          value:
+            RefineReadAndWrite:
+              write_key: 0
         loan_drop_refined:
           type: High
           value: 0
@@ -146,6 +157,8 @@ description: main@while_loop_0.test
           type: None
         loan_write_refined:
           type: None
+        loan_refined:
+          type: None
         loan_drop_refined:
           type: None
         permissions:
@@ -173,6 +186,8 @@ description: main@while_loop_0.test
         loan_read_refined:
           type: None
         loan_write_refined:
+          type: None
+        loan_refined:
           type: None
         loan_drop_refined:
           type: None
@@ -202,6 +217,8 @@ description: main@while_loop_0.test
         loan_read_refined:
           type: Low
         loan_write_refined:
+          type: Low
+        loan_refined:
           type: Low
         loan_drop_refined:
           type: Low
@@ -234,6 +251,8 @@ description: main@while_loop_0.test
           type: None
         loan_write_refined:
           type: None
+        loan_refined:
+          type: None
         loan_drop_refined:
           type: None
         permissions:
@@ -243,4 +262,3 @@ description: main@while_loop_0.test
             type: Low
           drop:
             type: Low
-

--- a/frontend/packages/aquascope-editor/src/editor-utils/stepper.tsx
+++ b/frontend/packages/aquascope-editor/src/editor-utils/stepper.tsx
@@ -132,6 +132,7 @@ let PermDiffRow = ({
     | "path_moved"
     | "path_uninitialized"
     | "loan_write_refined"
+    | "loan_read_write_refined"
     | "loan_read_refined";
 
   // There is a sort of hierarchy to the changing permissions:
@@ -156,7 +157,7 @@ let PermDiffRow = ({
       ]
     },
     {
-      fact: "loan_read_refined",
+      fact: "loan_read_write_refined",
       states: [
         {
           value: { type: "High", value: 0 },
@@ -167,21 +168,6 @@ let PermDiffRow = ({
           value: { type: "Low" },
           icon: "rotate-left",
           desc: "Borrow on place is dropped here"
-        }
-      ]
-    },
-    {
-      fact: "loan_write_refined",
-      states: [
-        {
-          value: { type: "High", value: 0 },
-          icon: "arrow-right",
-          desc: "Place is borrowed here"
-        },
-        {
-          value: { type: "Low" },
-          icon: "rotate-left",
-          desc: "Borrow on place is no longer used here"
         }
       ]
     },
@@ -199,35 +185,21 @@ let PermDiffRow = ({
           desc: "Place is no longer used here"
         }
       ]
-    },
-    {
-      fact: "path_uninitialized",
-      states: [
-        {
-          value: { type: "High", value: 0 },
-          icon: "sign-out",
-          desc: "Place contains uninitialized data"
-        },
-        {
-          value: { type: "Low" },
-          icon: "recycle",
-          desc: "Place data is initialized after move here"
-        }
-      ]
     }
   ];
 
-  let ico = null;
-  loop: for (let { fact, states } of visualFacts) {
+  let icos = [];
+  for (let { fact, states } of visualFacts) {
     for (let { value, icon, desc } of states) {
       if (_.isEqual(diffs[fact].type, value.type)) {
-        ico = (
-          <i
-            className={`fa fa-${icon} aquascope-action-indicator`}
-            title={desc}
-          />
+        icos.push(
+          <span className="perm-step-icon">
+            <i
+              className={`fa fa-${icon} aquascope-action-indicator`}
+              title={desc}
+            />
+          </span>
         );
-        break loop;
       } else {
         // console.log("unequal: ", diffs[fact].type, value.type);
       }
@@ -264,7 +236,7 @@ let PermDiffRow = ({
   return (
     <tr>
       {pathCol}
-      <td className="perm-step-event">{ico}</td>
+      <td className="perm-step-event">{icos}</td>
       {perms.map(perm => (
         <PermChar key={perm.perm} perm={perm} facts={facts} />
       ))}

--- a/frontend/packages/aquascope-editor/src/editor-utils/stepper.tsx
+++ b/frontend/packages/aquascope-editor/src/editor-utils/stepper.tsx
@@ -14,7 +14,7 @@ import type {
   PermissionsLineDisplay,
   PermissionsStepTable,
   StepperAnnotations,
-  ValueStep
+  ValueStep,
 } from "../types.js";
 import {
   hideLoanRegion,
@@ -26,7 +26,7 @@ import {
   readChar,
   showLoanRegion,
   showMoveRegion,
-  writeChar
+  writeChar,
 } from "./misc.js";
 
 interface PermInStep {
@@ -38,7 +38,7 @@ interface PermInStep {
 
 let PermChar = ({
   perm,
-  facts
+  facts,
 }: {
   perm: PermInStep;
   facts: AnalysisFacts;
@@ -110,7 +110,7 @@ let PermChar = ({
 let PermDiffRow = ({
   path,
   diffs,
-  facts
+  facts,
 }: {
   path: string;
   diffs: PermissionsDataDiff;
@@ -132,7 +132,7 @@ let PermDiffRow = ({
     | "path_moved"
     | "path_uninitialized"
     | "loan_write_refined"
-    | "loan_read_write_refined"
+    | "loan_refined"
     | "loan_read_refined";
 
   // There is a sort of hierarchy to the changing permissions:
@@ -147,29 +147,29 @@ let PermDiffRow = ({
         {
           value: { type: "High", value: 0 },
           icon: "sign-out",
-          desc: "Place is moved here"
+          desc: "Place is moved here",
         },
         {
           value: { type: "Low" },
           icon: "recycle",
-          desc: "Place is re-initialized after move here"
-        }
-      ]
+          desc: "Place is re-initialized after move here",
+        },
+      ],
     },
     {
-      fact: "loan_read_write_refined",
+      fact: "loan_refined",
       states: [
         {
           value: { type: "High", value: 0 },
           icon: "arrow-right",
-          desc: "Place is borrowed here"
+          desc: "Place is borrowed here",
         },
         {
           value: { type: "Low" },
           icon: "rotate-left",
-          desc: "Borrow on place is dropped here"
-        }
-      ]
+          desc: "Borrow on place is dropped here",
+        },
+      ],
     },
     {
       fact: "is_live",
@@ -177,15 +177,15 @@ let PermDiffRow = ({
         {
           value: { type: "High", value: 0 },
           icon: "level-up",
-          desc: "Place is initialized here"
+          desc: "Place is initialized here",
         },
         {
           value: { type: "Low" },
           icon: "level-down",
-          desc: "Place is no longer used here"
-        }
-      ]
-    }
+          desc: "Place is no longer used here",
+        },
+      ],
+    },
   ];
 
   let icos = [];
@@ -215,20 +215,20 @@ let PermDiffRow = ({
       perm: readChar,
       step: diffs.permissions.read,
       loanKey: unwrap(diffs.loan_read_refined),
-      moveKey
+      moveKey,
     },
     {
       perm: writeChar,
       step: diffs.permissions.write,
       loanKey: unwrap(diffs.loan_write_refined),
-      moveKey
+      moveKey,
     },
     {
       perm: ownChar,
       step: diffs.permissions.drop,
       loanKey: unwrap(diffs.loan_drop_refined),
-      moveKey
-    }
+      moveKey,
+    },
   ];
 
   let pathCol = <td className="perm-step-path">{path}</td>;
@@ -237,7 +237,7 @@ let PermDiffRow = ({
     <tr>
       {pathCol}
       <td className="perm-step-event">{icos}</td>
-      {perms.map(perm => (
+      {perms.map((perm) => (
         <PermChar key={perm.perm} perm={perm} facts={facts} />
       ))}
     </tr>
@@ -250,7 +250,7 @@ let stepLocation = (step: PermissionsLineDisplay): CharPos => {
 
 let StepTable = ({
   rows,
-  facts
+  facts,
 }: {
   rows: [string, PermissionsDataDiff][];
   facts: AnalysisFacts;
@@ -269,7 +269,7 @@ let StepTable = ({
 let StepTableIndividual = ({
   focused,
   hidden,
-  facts
+  facts,
 }: {
   focused: [string, PermissionsDataDiff][];
   hidden: [string, PermissionsDataDiff][];
@@ -291,7 +291,7 @@ let StepTableIndividual = ({
     // biome-ignore lint/a11y/useKeyWithClickEvents: TODO
     <div
       className={classNames("step-table-container", {
-        "contains-hidden": hidden.length > 0
+        "contains-hidden": hidden.length > 0,
       })}
       onClick={() => setDisplayAll(!displayAll)}
     >
@@ -308,7 +308,7 @@ let StepLine = ({
   focusedRegex,
   tables,
   init,
-  facts
+  facts,
 }: {
   spaces: string;
   focusedRegex: RegExp;
@@ -344,7 +344,7 @@ let StepLine = ({
       </span>
       <div
         className={classNames("step-widget-container", {
-          "hidden-width": !display
+          "hidden-width": !display,
         })}
       >
         <div className="step-widget-spacer">{spaces}</div>
@@ -394,12 +394,12 @@ class PermissionStepLineWidget extends WidgetType {
 
     let matchers = this.annotations?.focused_paths[currLine.number];
     let rx = matchers
-      ?.map(matcher =>
+      ?.map((matcher) =>
         matcher.type === "Literal"
           ? _.escapeRegExp(matcher.value)
           : matcher.value
       )
-      .map(s => `(${s})`)
+      .map((s) => `(${s})`)
       .join("|");
     let r = new RegExp(rx ?? "(.*)?");
 
@@ -431,10 +431,10 @@ export function makeStepDecorations(
   stateSteps: PermissionsLineDisplay[],
   annotations?: StepperAnnotations
 ): Range<Decoration>[] {
-  return stateSteps.map(step =>
+  return stateSteps.map((step) =>
     Decoration.widget({
       widget: new PermissionStepLineWidget(view, step, facts, annotations),
-      side: 1
+      side: 1,
     }).range(linecolToPosition(stepLocation(step), view.state.doc))
   );
 }

--- a/frontend/packages/aquascope-editor/src/editor-utils/stepper.tsx
+++ b/frontend/packages/aquascope-editor/src/editor-utils/stepper.tsx
@@ -14,7 +14,7 @@ import type {
   PermissionsLineDisplay,
   PermissionsStepTable,
   StepperAnnotations,
-  ValueStep,
+  ValueStep
 } from "../types.js";
 import {
   hideLoanRegion,
@@ -26,7 +26,7 @@ import {
   readChar,
   showLoanRegion,
   showMoveRegion,
-  writeChar,
+  writeChar
 } from "./misc.js";
 
 interface PermInStep {
@@ -38,7 +38,7 @@ interface PermInStep {
 
 let PermChar = ({
   perm,
-  facts,
+  facts
 }: {
   perm: PermInStep;
   facts: AnalysisFacts;
@@ -110,7 +110,7 @@ let PermChar = ({
 let PermDiffRow = ({
   path,
   diffs,
-  facts,
+  facts
 }: {
   path: string;
   diffs: PermissionsDataDiff;
@@ -147,14 +147,14 @@ let PermDiffRow = ({
         {
           value: { type: "High", value: 0 },
           icon: "sign-out",
-          desc: "Place is moved here",
+          desc: "Place is moved here"
         },
         {
           value: { type: "Low" },
           icon: "recycle",
-          desc: "Place is re-initialized after move here",
-        },
-      ],
+          desc: "Place is re-initialized after move here"
+        }
+      ]
     },
     {
       fact: "loan_refined",
@@ -162,14 +162,14 @@ let PermDiffRow = ({
         {
           value: { type: "High", value: 0 },
           icon: "arrow-right",
-          desc: "Place is borrowed here",
+          desc: "Place is borrowed here"
         },
         {
           value: { type: "Low" },
           icon: "rotate-left",
-          desc: "Borrow on place is dropped here",
-        },
-      ],
+          desc: "Borrow on place is dropped here"
+        }
+      ]
     },
     {
       fact: "is_live",
@@ -177,15 +177,15 @@ let PermDiffRow = ({
         {
           value: { type: "High", value: 0 },
           icon: "level-up",
-          desc: "Place is initialized here",
+          desc: "Place is initialized here"
         },
         {
           value: { type: "Low" },
           icon: "level-down",
-          desc: "Place is no longer used here",
-        },
-      ],
-    },
+          desc: "Place is no longer used here"
+        }
+      ]
+    }
   ];
 
   let icos = [];
@@ -215,20 +215,20 @@ let PermDiffRow = ({
       perm: readChar,
       step: diffs.permissions.read,
       loanKey: unwrap(diffs.loan_read_refined),
-      moveKey,
+      moveKey
     },
     {
       perm: writeChar,
       step: diffs.permissions.write,
       loanKey: unwrap(diffs.loan_write_refined),
-      moveKey,
+      moveKey
     },
     {
       perm: ownChar,
       step: diffs.permissions.drop,
       loanKey: unwrap(diffs.loan_drop_refined),
-      moveKey,
-    },
+      moveKey
+    }
   ];
 
   let pathCol = <td className="perm-step-path">{path}</td>;
@@ -237,7 +237,7 @@ let PermDiffRow = ({
     <tr>
       {pathCol}
       <td className="perm-step-event">{icos}</td>
-      {perms.map((perm) => (
+      {perms.map(perm => (
         <PermChar key={perm.perm} perm={perm} facts={facts} />
       ))}
     </tr>
@@ -250,7 +250,7 @@ let stepLocation = (step: PermissionsLineDisplay): CharPos => {
 
 let StepTable = ({
   rows,
-  facts,
+  facts
 }: {
   rows: [string, PermissionsDataDiff][];
   facts: AnalysisFacts;
@@ -269,7 +269,7 @@ let StepTable = ({
 let StepTableIndividual = ({
   focused,
   hidden,
-  facts,
+  facts
 }: {
   focused: [string, PermissionsDataDiff][];
   hidden: [string, PermissionsDataDiff][];
@@ -291,7 +291,7 @@ let StepTableIndividual = ({
     // biome-ignore lint/a11y/useKeyWithClickEvents: TODO
     <div
       className={classNames("step-table-container", {
-        "contains-hidden": hidden.length > 0,
+        "contains-hidden": hidden.length > 0
       })}
       onClick={() => setDisplayAll(!displayAll)}
     >
@@ -308,7 +308,7 @@ let StepLine = ({
   focusedRegex,
   tables,
   init,
-  facts,
+  facts
 }: {
   spaces: string;
   focusedRegex: RegExp;
@@ -344,7 +344,7 @@ let StepLine = ({
       </span>
       <div
         className={classNames("step-widget-container", {
-          "hidden-width": !display,
+          "hidden-width": !display
         })}
       >
         <div className="step-widget-spacer">{spaces}</div>
@@ -394,12 +394,12 @@ class PermissionStepLineWidget extends WidgetType {
 
     let matchers = this.annotations?.focused_paths[currLine.number];
     let rx = matchers
-      ?.map((matcher) =>
+      ?.map(matcher =>
         matcher.type === "Literal"
           ? _.escapeRegExp(matcher.value)
           : matcher.value
       )
-      .map((s) => `(${s})`)
+      .map(s => `(${s})`)
       .join("|");
     let r = new RegExp(rx ?? "(.*)?");
 
@@ -431,10 +431,10 @@ export function makeStepDecorations(
   stateSteps: PermissionsLineDisplay[],
   annotations?: StepperAnnotations
 ): Range<Decoration>[] {
-  return stateSteps.map((step) =>
+  return stateSteps.map(step =>
     Decoration.widget({
       widget: new PermissionStepLineWidget(view, step, facts, annotations),
-      side: 1,
+      side: 1
     }).range(linecolToPosition(stepLocation(step), view.state.doc))
   );
 }


### PR DESCRIPTION
Potential way of addressing #85 by adding an icon for every diff reason. Naively adding these duplicate icons leads to two immediate undesirable consequences:

* The `read_refined` and `write_refined` are considered separate diff reasons and both become duplicated in the frontend.
* The `path_uninitialized` relation and `path_moved` significantly overlap and both become displayed in the frontend.

Since these extra duplications are unintuitive, two fixes are applied:

* We unify `read_refined` and `write_refined` in the frontend.
* We remove `path_uninitialized` from the frontend.

The result is that we get multiple icons in places where they are expected (as in the snippet provided in #85), and not where they are unintuitive or distracting.

---

# Screenshots

These screenshots show all known differences to existing diagrams.

| Description                                             | Screenshot (Before)                                                                                          | Screenshot (After)                                                                                         |
|---------------------------------------------------------|-------------------------------------------------------------------------------------------------------------|------------------------------------------------------------------------------------------------------------|
| From 4.3 in the CEL's TRPL "Copying vs. Moving Out of a Collection" | ![dereference example screenshot before](https://github.com/user-attachments/assets/623f8cab-648a-4e4e-ab5a-a930f39077d3) | ![dereference example screenshot after](https://github.com/user-attachments/assets/fc2fc9b3-54b4-4fb5-8cfd-8fc8567a2edb) |
| The diagram immediately following this one in the book | ![subsequent-diagram screenshot before](https://github.com/user-attachments/assets/83450b63-e8fc-4a0a-81db-ce5fb1ecd5a1) | ![subsequent-diagram screenshot after](https://github.com/user-attachments/assets/b7f5d04a-d876-4ab5-9e48-f5e6f25f9aee) |
| From Issue #85                                      | ![issue-85 screenshot before](https://github.com/user-attachments/assets/f9aeb552-051b-4805-96f9-0d14d0043179)   | ![issue-85 screenshot after](https://github.com/user-attachments/assets/e295d033-be6c-48ef-8b86-767d5c4e963c)   |



