### PR TITLE
Update Installation with Proper Flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ We provide an [mdBook](https://rust-lang.github.io/mdBook/) preprocessor that em
 
 ```sh
 cargo install mdbook-aquascope --locked --version 0.3.5
-rustup toolchain install nightly-2024-12-15 -c rust-src rustc-dev llvm-tools-preview miri
+rustup toolchain install nightly-2024-12-15 -c rust-src -c rustc-dev -c llvm-tools-preview -c miri
 cargo +nightly-2024-12-15 install aquascope_front --git https://github.com/cognitive-engineering-lab/aquascope --tag v0.3.5 --locked
 cargo +nightly-2024-12-15 miri setup
 ```


### PR DESCRIPTION
```bash
❯ rustup toolchain install nightly-2024-12-15 -c rust-src rustc-dev llvm-tools-preview miri
error: invalid value 'rustc-dev' for '[TOOLCHAIN]...': invalid toolchain name: 'rustc-dev'

For more information, try '--help'.
```

`-c` needs to be specified for each component:

```bash
❯ rustup toolchain install nightly-2023-08-25 -c rust-src -c llvm-tools-preview -c miri -c rustc-dev
info: syncing channel updates for 'nightly-2023-08-25-aarch64-apple-darwin'
info: latest update on 2023-08-25, rust version 1.74.0-nightly (58eefc33a 2023-08-24)
info: component 'miri' for target 'aarch64-apple-darwin' is up to date
info: component 'rust-src' is up to date
info: downloading component 'llvm-tools'
 32.8 MiB /  32.8 MiB (100 %)  24.7 MiB/s in  1s         i
info: downloading component 'rustc-dev'
 94.8 MiB /  94.8 MiB (100 %)  21.2 MiB/s in  4s         
info: installing component 'llvm-tools'
 32.8 MiB /  32.8 MiB (100 %)  20.6 MiB/s in  1s         
info: installing component 'rustc-dev'
 94.8 MiB /  94.8 MiB (100 %)  20.0 MiB/s in  4s
```