### PR TITLE
Update rustup toolchain install command

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ We provide an [mdBook](https://rust-lang.github.io/mdBook/) preprocessor that em
 
 ```sh
 cargo install mdbook-aquascope --locked --version 0.3.5
-rustup toolchain install nightly-2024-12-15 -c rust-src rustc-dev llvm-tools-preview miri
+rustup toolchain install nightly-2024-12-15 -c rust-src,rustc-dev,llvm-tools-preview,miri
 cargo +nightly-2024-12-15 install aquascope_front --git https://github.com/cognitive-engineering-lab/aquascope --tag v0.3.5 --locked
 cargo +nightly-2024-12-15 miri setup
 ```


### PR DESCRIPTION
The command from the docs is not valid, the arguments should be comma separated. Without the commas, a user will receive an error that the toolchain install target is not valid.

This can be seen in the build ci for the rust book repo https://github.com/cognitive-engineering-lab/rust-book/blob/04b776b0f51596b9b3eb80446bba531e556c446e/.github/workflows/main.yml#L45